### PR TITLE
Refactor bridge pallet types

### DIFF
--- a/pallets/alpha-bridge/src/mock.rs
+++ b/pallets/alpha-bridge/src/mock.rs
@@ -156,7 +156,7 @@ pub fn run_to_block(n: u64) {
 // Helper function to create a test deposit proposal with unique ID
 pub fn create_deposit_proposal(
 	recipient: AccountId,
-	amount: Balance,
+	amount: u64,
 ) -> pallet_alpha_bridge::DepositProposal<AccountId> {
 	use sp_core::Hasher;
 	use sp_runtime::traits::BlakeTwo256;


### PR DESCRIPTION
- Change BurnId from u128 to H256 (hash-based using blake2_256)
- Change amount type from u128 to u64 (aligned with Bittensor)
- Remove bittensor_coldkey parameter (requester account used as destination)
- Update all tests and benchmarks