### PR TITLE
docs: fix misleading weight TODO comments in subAccounts pallet

### DIFF
--- a/pallets/subAccounts/src/lib.rs
+++ b/pallets/subAccounts/src/lib.rs
@@ -149,7 +149,7 @@ pub mod pallet {
 		///
 		/// Emits `SubAccountAdded` event when successful.
 		///
-		/// Weight: `O(1)` TODO: Add correct weight
+		/// Weight is sourced from benchmark measurements via `T::WeightInfo::add_sub_account()`.
 		#[pallet::call_index(0)]
 		pub fn add_sub_account(
 			origin: OriginFor<T>,
@@ -211,7 +211,7 @@ pub mod pallet {
 		///
 		/// Emits `SubAccountRemoved` event when successful.
 		///
-		/// Weight: `O(1)` TODO: Add correct weight
+		/// Weight is sourced from benchmark measurements via `T::WeightInfo::remove_sub_account()`.
 		#[pallet::call_index(1)]
 		pub fn remove_sub_account(
 			origin: OriginFor<T>,


### PR DESCRIPTION
## What

Fixes two misleading doc comments in `pallets/subAccounts/src/lib.rs` that said:

```
Weight: O(1) TODO: Add correct weight
```

The weights were already correctly wired via `#[pallet::call(weight(<T as Config>::WeightInfo))]` on the call block, sourcing real benchmark values from `weights.rs` (~41ms/~52ms). The TODO comments were outdated and could confuse contributors into thinking weights were missing.

## Changes

- `add_sub_account` doc: updated to reference `T::WeightInfo::add_sub_account()`
- `remove_sub_account` doc: updated to reference `T::WeightInfo::remove_sub_account()`

No logic changes. Doc-only fix.

---

*Contributed by T68Bot from Project Nobi (projectnobi.ai)*