### PR TITLE
feat(compute-scoring): new pallet for the Hippius §23 scheduler signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
  "pallet-calendar",
  "pallet-child-bounties",
  "pallet-collective",
+ "pallet-compute-scoring",
  "pallet-credits",
  "pallet-democracy",
  "pallet-dynamic-fee",
@@ -8129,6 +8130,22 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "sp-core 34.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.3",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
+]
+
+[[package]]
+name = "pallet-compute-scoring"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.1.0",
+ "frame-system 37.1.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
  "sp-core 34.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
  "sp-io 38.0.0",
  "sp-runtime 39.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,6 +371,7 @@ pallet-subaccount  = { path = "pallets/subAccounts", default-features = false }
 #pallet-backup = { path = "pallets/backup", default-features = false }
 pallet-credits = { path = "pallets/credits", default-features = false }
 pallet-compute = { path = "pallets/compute", default-features = false }
+pallet-compute-scoring = { path = "pallets/compute-scoring", default-features = false }
 pallet-container-registry = { path = "pallets/containerRegistry", default-features = false }
 lite-json = { version = "0.2.0", default-features = false }
 

--- a/pallets/compute-scoring/Cargo.toml
+++ b/pallets/compute-scoring/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "pallet-compute-scoring"
+description = "§23 compute-scheduler signal: per-epoch miner reward weight (derived from pallet-arion) + the §13 miner status state machine, in the exact on-chain shape the hippius-compute `read-miner-status` reader decodes."
+version = "0.1.0"
+license = "MIT"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { features = ["derive"], workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+sp-std = { default-features = false, workspace = true }
+sp-runtime = { default-features = false, workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+frame-benchmarking = { optional = true, workspace = true }
+log = { version = "0.4.22", default-features = false }
+
+[dev-dependencies]
+sp-core = { default-features = false, workspace = true }
+sp-io = { default-features = false, workspace = true }
+sp-runtime = { default-features = false, workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"scale-info/std",
+	"sp-std/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+	"frame-benchmarking?/std",
+	"log/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/pallets/compute-scoring/src/benchmarking.rs
+++ b/pallets/compute-scoring/src/benchmarking.rs
@@ -1,0 +1,31 @@
+//! Benchmarks for `pallet-compute-scoring`.
+//!
+//! `set_miner_status` is benchmarked here (O(1)). `close_epoch` is charged
+//! at its worst case (`n = MaxMinersPerEpochClose`) via the hand-estimated
+//! `SubstrateWeight::close_epoch(n)` in `weights.rs` — a real linear bench
+//! needs the runtime's Arion-backed `Merit` populated with `n` registered
+//! miners, which is a runtime-integration benchmark (a follow-up); the
+//! worst-case charge is always safe (never under-weighs).
+
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::*;
+use crate::pallet::Pallet;
+use frame_benchmarking::v2::*;
+use frame_system::RawOrigin;
+
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn set_miner_status() {
+		let node: NodeId = [7u8; 32];
+		#[extrinsic_call]
+		_(RawOrigin::Root, node, MinerStatus::Quarantined);
+
+		assert!(crate::pallet::MinerStatuses::<T>::get(node).is_some());
+	}
+
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/compute-scoring/src/lib.rs
+++ b/pallets/compute-scoring/src/lib.rs
@@ -1,0 +1,278 @@
+//! # pallet-compute-scoring
+//!
+//! The on-chain signal the Hippius §23 confidential-compute scheduler
+//! reads to **score** and **rank** miners for VM placement. The scheduler
+//! (off-chain, in `hippius-compute`) shells out to a `read-miner-status`
+//! binary that decodes this pallet's storage over JSON-RPC; this pallet
+//! exists so that decode succeeds with a real merit signal.
+//!
+//! ## Why a separate pallet (and why these exact names)
+//!
+//! `read-miner-status` derives storage keys as
+//! `twox_128("ComputeScoring") ++ twox_128(<Item>) ++ …` and decodes
+//! fixed SCALE shapes. So this pallet MUST be wired into the runtime under
+//! the name **`ComputeScoring`**, and its storage items MUST be named
+//! exactly `CurrentEpoch`, `NodeIdToChild`, `MinerStatuses`,
+//! `EpochWeights` with the value shapes below. The reader is the frozen
+//! contract; this pallet is written to satisfy it (see `tests.rs`, which
+//! re-asserts the byte layout the reader's `decode_*` functions expect).
+//!
+//! ## What it does NOT do
+//!
+//! It does NOT compute merit. The deployed, validator-authority-gated,
+//! anti-cheat node weight already lives in [`pallet_arion`]
+//! (`NodeWeightByChild`, a `u16` blend of bandwidth/storage/uptime with
+//! strike + integrity penalties). This pallet **buckets** that weight into
+//! a per-epoch, node_id-keyed `u128` (`EpochWeights`) on each
+//! `close_epoch`, and holds the §13 miner status state machine
+//! (`MinerStatuses`) the scheduler gates + drains on. One source of merit
+//! truth (Arion); this is the epoch+status projection the scheduler reads.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+pub mod weights;
+pub use weights::WeightInfo;
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+/// A miner's §13 lifecycle status. SCALE-encodes by variant index, so the
+/// discriminants are `Active = 0`, `Quarantined = 1`, `Decommissioned = 2`
+/// — the exact bytes `read-miner-status::miner_status_label` maps. The
+/// declaration order is therefore load-bearing; do NOT reorder.
+#[derive(
+	Clone, Copy, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
+)]
+pub enum MinerStatus {
+	/// Schedulable. The registry default — a registered miner with no
+	/// `MinerStatuses` row IS Active (the reader assumes this), so an
+	/// Active status is stored as the ABSENCE of a row, never a `0` row.
+	Active,
+	/// §13 quarantine — suspected ghost load / repeated failures.
+	/// Excluded from placement + drained from any bound placement.
+	Quarantined,
+	/// Permanently retired. Excluded from placement.
+	Decommissioned,
+}
+
+/// The per-miner status record. **Field order is load-bearing**:
+/// `read-miner-status::decode_miner_status_entry` reads `status` from the
+/// FIRST byte and `last_transition_epoch` from the TRAILING 8 bytes,
+/// agnostic to the `BlockNumber` width in the middle. Keep `status` first
+/// and `last_transition_epoch` last.
+#[derive(
+	Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen,
+)]
+pub struct MinerStatusEntry<BlockNumber> {
+	/// The status discriminant (head byte).
+	pub status: MinerStatus,
+	/// Block the status last changed (audit; the reader skips it).
+	pub last_transition_block: BlockNumber,
+	/// Epoch the status last changed (trailing u64 — the reader's
+	/// `data_epoch` fallback for an unscored miner).
+	pub last_transition_epoch: u64,
+}
+
+use frame_support::pallet_prelude::RuntimeDebug;
+
+/// A miner's 32-byte compute node id (the on-chain registration key).
+pub type NodeId = [u8; 32];
+
+/// The per-miner merit source `close_epoch` snapshots into `EpochWeights`.
+///
+/// The runtime wires this to `pallet-arion` (read `NodeIdToChild` +
+/// `NodeWeightByChild`), keeping this pallet decoupled from Arion's full
+/// `Config` (and its registration/balances deps) so the test mock stays
+/// light. Yields `(node_id, child_account, weight_u128)` for every
+/// registered miner.
+pub trait MeritSource<AccountId> {
+	fn registered_miners() -> sp_std::vec::Vec<(NodeId, AccountId, u128)>;
+}
+
+/// No miners — a valid (empty-fleet) source, and the trivial test default.
+impl<AccountId> MeritSource<AccountId> for () {
+	fn registered_miners() -> sp_std::vec::Vec<(NodeId, AccountId, u128)> {
+		sp_std::vec::Vec::new()
+	}
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The aggregated event type.
+		type RuntimeEvent: From<Event<Self>>
+			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Who may close an epoch (snapshot the merit weights) and set a
+		/// miner status — the validator set / a council origin, the same
+		/// authority that drives Arion's weights.
+		type AuthorityOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// The per-miner merit weights to snapshot each epoch (the runtime
+		/// wires this to pallet-arion).
+		type Merit: MeritSource<Self::AccountId>;
+
+		/// Safety cap on miners processed in one `close_epoch` — bounds
+		/// the extrinsic's weight. A fleet larger than this fails closed
+		/// (the authority must raise the cap via a runtime upgrade rather
+		/// than silently skip miners, which would zero their score).
+		#[pallet::constant]
+		type MaxMinersPerEpochClose: Get<u32>;
+
+		/// Weights.
+		type WeightInfo: WeightInfo;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	// ── Storage (byte-matched to the `read-miner-status` contract) ──────
+
+	/// The current scoring epoch. Bumped by [`Pallet::close_epoch`].
+	/// `ValueQuery` (absent ⇒ 0), matching the reader.
+	#[pallet::storage]
+	pub type CurrentEpoch<T> = StorageValue<_, u64, ValueQuery>;
+
+	/// Registered-miner registry mirror: `node_id → child account`.
+	/// Mirrored from `pallet_arion::NodeIdToChild` on each `close_epoch`.
+	/// The reader ENUMERATES the keys (every registered miner) and never
+	/// decodes the value — but we store the child so the map is useful +
+	/// matches Arion's shape.
+	#[pallet::storage]
+	pub type NodeIdToChild<T: Config> =
+		StorageMap<_, Blake2_128Concat, NodeId, T::AccountId, OptionQuery>;
+
+	/// **Sparse** miner status: a row exists ONLY for a non-Active miner
+	/// (Quarantined / Decommissioned). Absence ⇒ Active. The reader relies
+	/// on this — it enumerates `NodeIdToChild`, not this map.
+	#[pallet::storage]
+	pub type MinerStatuses<T: Config> =
+		StorageMap<_, Blake2_128Concat, NodeId, MinerStatusEntry<BlockNumberFor<T>>, OptionQuery>;
+
+	/// `EpochWeights[epoch][node_id] → u128` — the per-epoch reward weight
+	/// the scheduler ranks by (`quality`). Written by `close_epoch` from
+	/// Arion's `NodeWeightByChild`. Absent ⇒ not scored this epoch ⇒ the
+	/// reader treats `quality = 0` and the miner stale-gates closed.
+	#[pallet::storage]
+	pub type EpochWeights<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		u64,
+		Blake2_128Concat,
+		NodeId,
+		u128,
+		OptionQuery,
+	>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// An epoch was closed: `epoch` is the NEW current epoch,
+		/// `miners_scored` rows were written into `EpochWeights`.
+		EpochClosed { epoch: u64, miners_scored: u32 },
+		/// A miner's status changed (`Active` clears the row).
+		MinerStatusChanged { node_id: NodeId, status: MinerStatus },
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The registered-miner count exceeds `MaxMinersPerEpochClose`.
+		/// Raise the cap (runtime upgrade) rather than silently skip.
+		TooManyMiners,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Close the current epoch: snapshot every registered miner's
+		/// Arion weight into `EpochWeights[next_epoch][node_id]`, refresh
+		/// the `NodeIdToChild` mirror, and bump `CurrentEpoch`.
+		///
+		/// Authority-gated (`AuthorityOrigin`) — the same validator/council
+		/// authority that updates Arion's weights. Idempotent per epoch in
+		/// effect: re-running just overwrites the next epoch's rows.
+		///
+		/// The reader's `data_epoch` freshness gate keys off whether a
+		/// miner has an `EpochWeights[current][node_id]` row, so this MUST
+		/// run each scoring epoch for the scheduler to see fresh scores.
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::WeightInfo::close_epoch(T::MaxMinersPerEpochClose::get()))]
+		pub fn close_epoch(origin: OriginFor<T>) -> DispatchResult {
+			T::AuthorityOrigin::ensure_origin(origin)?;
+
+			let cap = T::MaxMinersPerEpochClose::get();
+			let miners = T::Merit::registered_miners();
+			// Fail closed (no partial epoch) if over the cap.
+			ensure!(miners.len() as u32 <= cap, Error::<T>::TooManyMiners);
+
+			let next = CurrentEpoch::<T>::get().saturating_add(1);
+			let mut scored: u32 = 0;
+			for (node_id, child, weight) in miners {
+				// Refresh the registry mirror so the reader's enumeration
+				// reflects the current registration set.
+				NodeIdToChild::<T>::insert(node_id, child);
+				EpochWeights::<T>::insert(next, node_id, weight);
+				scored = scored.saturating_add(1);
+			}
+			CurrentEpoch::<T>::put(next);
+			Self::deposit_event(Event::EpochClosed { epoch: next, miners_scored: scored });
+			Ok(())
+		}
+
+		/// Set a miner's §13 status. `Active` REMOVES the row (the sparse
+		/// invariant the reader depends on); any non-Active status writes a
+		/// `MinerStatusEntry` stamped with the current block + epoch.
+		/// Authority-gated.
+		#[pallet::call_index(1)]
+		#[pallet::weight(T::WeightInfo::set_miner_status())]
+		pub fn set_miner_status(
+			origin: OriginFor<T>,
+			node_id: NodeId,
+			status: MinerStatus,
+		) -> DispatchResult {
+			T::AuthorityOrigin::ensure_origin(origin)?;
+
+			match status {
+				MinerStatus::Active => {
+					// Sparse: clearing to Active is the absence of a row.
+					MinerStatuses::<T>::remove(node_id);
+				}
+				_ => {
+					MinerStatuses::<T>::insert(
+						node_id,
+						MinerStatusEntry {
+							status,
+							last_transition_block: frame_system::Pallet::<T>::block_number(),
+							last_transition_epoch: CurrentEpoch::<T>::get(),
+						},
+					);
+				}
+			}
+			Self::deposit_event(Event::MinerStatusChanged { node_id, status });
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Read helper: the effective status of a miner (absent row ⇒
+		/// Active). Used by tests + any in-runtime consumer.
+		pub fn status_of(node_id: &NodeId) -> MinerStatus {
+			MinerStatuses::<T>::get(node_id)
+				.map(|e| e.status)
+				.unwrap_or(MinerStatus::Active)
+		}
+	}
+}

--- a/pallets/compute-scoring/src/mock.rs
+++ b/pallets/compute-scoring/src/mock.rs
@@ -1,0 +1,80 @@
+//! Test runtime for `pallet-compute-scoring`.
+//!
+//! Deliberately light: the merit source is decoupled behind
+//! [`super::MeritSource`], so the mock wires a `thread_local` fake instead
+//! of pulling in pallet-arion + its registration/balances dependencies.
+
+use crate as pallet_compute_scoring;
+use core::cell::RefCell;
+use frame_support::{derive_impl, traits::EnsureOrigin};
+use sp_runtime::{traits::IdentityLookup, BuildStorage};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		ComputeScoring: pallet_compute_scoring,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+}
+
+thread_local! {
+	static MINERS: RefCell<sp_std::vec::Vec<([u8; 32], u64, u128)>> = const { RefCell::new(sp_std::vec::Vec::new()) };
+}
+
+/// Test merit source — `set_miners` controls what `close_epoch` snapshots.
+pub struct MockMerit;
+impl pallet_compute_scoring::MeritSource<u64> for MockMerit {
+	fn registered_miners() -> sp_std::vec::Vec<([u8; 32], u64, u128)> {
+		MINERS.with(|m| m.borrow().clone())
+	}
+}
+
+/// Set the fleet the next `close_epoch` will snapshot.
+pub fn set_miners(v: sp_std::vec::Vec<([u8; 32], u64, u128)>) {
+	MINERS.with(|m| *m.borrow_mut() = v);
+}
+
+/// An origin that always passes the authority check (the mock's "council").
+pub struct AlwaysAuthority;
+impl EnsureOrigin<RuntimeOrigin> for AlwaysAuthority {
+	type Success = ();
+	fn try_origin(o: RuntimeOrigin) -> Result<Self::Success, RuntimeOrigin> {
+		// Accept Root; reject everything else (so we can test the gate).
+		match o.clone().into() {
+			Ok(frame_system::RawOrigin::Root) => Ok(()),
+			_ => Err(o),
+		}
+	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<RuntimeOrigin, ()> {
+		Ok(RuntimeOrigin::root())
+	}
+}
+
+frame_support::parameter_types! {
+	pub const MaxMinersPerEpochClose: u32 = 1_000;
+}
+
+impl pallet_compute_scoring::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type AuthorityOrigin = AlwaysAuthority;
+	type Merit = MockMerit;
+	type MaxMinersPerEpochClose = MaxMinersPerEpochClose;
+	type WeightInfo = ();
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	set_miners(sp_std::vec::Vec::new());
+	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	let mut ext: sp_io::TestExternalities = t.into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/pallets/compute-scoring/src/tests.rs
+++ b/pallets/compute-scoring/src/tests.rs
@@ -1,0 +1,149 @@
+//! Tests for `pallet-compute-scoring`.
+//!
+//! Two kinds: behaviour (close_epoch / set_miner_status semantics) and the
+//! **byte-layout conformance** that the hippius-compute `read-miner-status`
+//! reader depends on — those tests re-assert exactly what the reader's
+//! `decode_miner_status_entry` / `scale_u128` / `miner_status_label`
+//! functions expect, so a drift here breaks CI before it breaks the chain.
+
+use crate::mock::*;
+use crate::{
+	CurrentEpoch, EpochWeights, MinerStatus, MinerStatusEntry, MinerStatuses,
+	NodeIdToChild,
+};
+use codec::Encode;
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::DispatchError;
+
+fn nid(b: u8) -> [u8; 32] {
+	[b; 32]
+}
+
+// ── byte-layout conformance (the reader's frozen contract) ───────────
+
+#[test]
+fn miner_status_discriminants_match_the_reader() {
+	// read-miner-status::miner_status_label maps 0/1/2.
+	assert_eq!(MinerStatus::Active.encode(), vec![0u8]);
+	assert_eq!(MinerStatus::Quarantined.encode(), vec![1u8]);
+	assert_eq!(MinerStatus::Decommissioned.encode(), vec![2u8]);
+}
+
+#[test]
+fn miner_status_entry_scale_layout_matches_decode_miner_status_entry() {
+	// The reader reads status from byte 0 and last_transition_epoch from
+	// the TRAILING 8 bytes, agnostic to the BlockNumber width between.
+	let entry = MinerStatusEntry::<u64> {
+		status: MinerStatus::Quarantined,
+		last_transition_block: 42,
+		last_transition_epoch: 1_234_567,
+	};
+	let bytes = entry.encode();
+	// Head byte = status discriminant.
+	assert_eq!(bytes[0], 1u8);
+	// Trailing 8 bytes = epoch, little-endian (SCALE u64).
+	assert_eq!(&bytes[bytes.len() - 8..], &1_234_567u64.to_le_bytes());
+	// Mock block number is u64 here, but the reader tolerates u32 too —
+	// the invariant is head=status, tail=epoch, which holds either way.
+}
+
+#[test]
+fn epoch_weight_value_is_a_plain_u128() {
+	// EpochWeights values decode via scale_u128 (16 LE bytes).
+	let w: u128 = 9_000_000_000_000_000_000_000; // > u64 to prove u128.
+	assert_eq!(w.encode(), w.to_le_bytes().to_vec());
+}
+
+// ── close_epoch behaviour ────────────────────────────────────────────
+
+#[test]
+fn close_epoch_snapshots_merit_into_epoch_weights_and_bumps() {
+	new_test_ext().execute_with(|| {
+		set_miners(vec![(nid(1), 100, 7), (nid(2), 200, 0)]);
+		assert_eq!(CurrentEpoch::<Test>::get(), 0);
+
+		assert_ok!(ComputeScoring::close_epoch(RuntimeOrigin::root()));
+
+		assert_eq!(CurrentEpoch::<Test>::get(), 1);
+		// Weights bucketed under the NEW epoch (1), keyed by node_id.
+		assert_eq!(EpochWeights::<Test>::get(1, nid(1)), Some(7u128));
+		assert_eq!(EpochWeights::<Test>::get(1, nid(2)), Some(0u128));
+		// Registry mirror refreshed (child accounts).
+		assert_eq!(NodeIdToChild::<Test>::get(nid(1)), Some(100u64));
+		assert_eq!(NodeIdToChild::<Test>::get(nid(2)), Some(200u64));
+	});
+}
+
+#[test]
+fn close_epoch_is_authority_gated() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			ComputeScoring::close_epoch(RuntimeOrigin::signed(1)),
+			DispatchError::BadOrigin
+		);
+		assert_eq!(CurrentEpoch::<Test>::get(), 0);
+	});
+}
+
+#[test]
+fn close_epoch_fails_closed_over_the_cap() {
+	new_test_ext().execute_with(|| {
+		// MaxMinersPerEpochClose is 1_000 in the mock; exceed it.
+		let many: Vec<_> = (0..1_001u32)
+			.map(|i| {
+				let mut n = [0u8; 32];
+				n[..4].copy_from_slice(&i.to_le_bytes());
+				(n, i as u64, 1u128)
+			})
+			.collect();
+		set_miners(many);
+		assert_noop!(
+			ComputeScoring::close_epoch(RuntimeOrigin::root()),
+			crate::Error::<Test>::TooManyMiners
+		);
+		// No partial epoch.
+		assert_eq!(CurrentEpoch::<Test>::get(), 0);
+	});
+}
+
+// ── set_miner_status behaviour ───────────────────────────────────────
+
+#[test]
+fn set_miner_status_is_sparse_active_clears_the_row() {
+	new_test_ext().execute_with(|| {
+		// Quarantine writes a row stamped with the current epoch.
+		CurrentEpoch::<Test>::put(5);
+		assert_ok!(ComputeScoring::set_miner_status(
+			RuntimeOrigin::root(),
+			nid(1),
+			MinerStatus::Quarantined
+		));
+		let e = MinerStatuses::<Test>::get(nid(1)).expect("row");
+		assert_eq!(e.status, MinerStatus::Quarantined);
+		assert_eq!(e.last_transition_epoch, 5);
+		assert_eq!(ComputeScoring::status_of(&nid(1)), MinerStatus::Quarantined);
+
+		// Recovering to Active REMOVES the row (the sparse invariant).
+		assert_ok!(ComputeScoring::set_miner_status(
+			RuntimeOrigin::root(),
+			nid(1),
+			MinerStatus::Active
+		));
+		assert!(MinerStatuses::<Test>::get(nid(1)).is_none());
+		assert_eq!(ComputeScoring::status_of(&nid(1)), MinerStatus::Active);
+	});
+}
+
+#[test]
+fn set_miner_status_is_authority_gated() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			ComputeScoring::set_miner_status(
+				RuntimeOrigin::signed(1),
+				nid(1),
+				MinerStatus::Decommissioned
+			),
+			DispatchError::BadOrigin
+		);
+	});
+}

--- a/pallets/compute-scoring/src/weights.rs
+++ b/pallets/compute-scoring/src/weights.rs
@@ -1,0 +1,50 @@
+//! Weights for `pallet-compute-scoring`.
+//!
+//! `close_epoch` scales with the registered-miner count (one Arion read +
+//! two writes per miner); `set_miner_status` is O(1). The `SubstrateWeight`
+//! values below are conservative hand estimates pending a
+//! `cargo run --features runtime-benchmarks` regeneration via
+//! `benchmarking.rs` (the worst case is `n = MaxMinersPerEpochClose`).
+
+#![allow(clippy::unnecessary_cast)]
+
+use core::marker::PhantomData;
+use frame_support::weights::{constants::RocksDbWeight, Weight};
+
+/// Weight functions needed for `pallet-compute-scoring`.
+pub trait WeightInfo {
+	/// `n` = number of registered miners snapshotted this epoch.
+	fn close_epoch(n: u32) -> Weight;
+	fn set_miner_status() -> Weight;
+}
+
+/// Weights derived from the Substrate node + `RocksDbWeight`.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	fn close_epoch(n: u32) -> Weight {
+		// Base + per-miner (1 Arion read + 2 writes). Reads: NodeIdToChild
+		// iter (n) + NodeWeightByChild (n); writes: NodeIdToChild mirror
+		// (n) + EpochWeights (n) + CurrentEpoch (1).
+		Weight::from_parts(15_000_000, 0)
+			.saturating_add(Weight::from_parts(25_000_000, 0).saturating_mul(n as u64))
+			.saturating_add(RocksDbWeight::get().reads((2 * n + 1) as u64))
+			.saturating_add(RocksDbWeight::get().writes((2 * n + 1) as u64))
+	}
+
+	fn set_miner_status() -> Weight {
+		Weight::from_parts(12_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(1))
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+}
+
+/// Unit weights for mocks / tests.
+impl WeightInfo for () {
+	fn close_epoch(_n: u32) -> Weight {
+		Weight::from_parts(0, 0)
+	}
+	fn set_miner_status() -> Weight {
+		Weight::from_parts(0, 0)
+	}
+}

--- a/runtime/mainnet/Cargo.toml
+++ b/runtime/mainnet/Cargo.toml
@@ -154,6 +154,7 @@ pallet-account-profile-precompile = { workspace = true }
 # pallet-notifications-precompile = { workspace = true }
 pallet-ip = { workspace = true }
 pallet-calendar = { workspace = true }
+pallet-compute-scoring = { workspace = true }
 
 
 evm-tracer = { workspace = true }
@@ -279,6 +280,7 @@ std = [
     
     "pallet-ip/std",
     "pallet-calendar/std",
+    "pallet-compute-scoring/std",
     #"ipfs-pallet/std",
     "pallet-alpha-bridge/std",
 	"pallet-registration/std",

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -168,6 +168,41 @@ impl pallet_arion::Config for Runtime {
 	type MinerStatsPruneInterval = ArionMinerStatsPruneInterval;
 	type MinerStatsPruneMaxScanPerBlock = ArionMinerStatsPruneMaxScanPerBlock;
 }
+
+// ── pallet-compute-scoring (§23 scheduler signal) ───────────────────────
+//
+// Bridges pallet-arion's deployed, validator-gated node weights into the
+// per-epoch, node_id-keyed `u128` shape the hippius-compute scheduler reads,
+// and holds the §13 miner status state machine. `ComputeScoring` derives its
+// score from Arion — it does NOT compute merit.
+pub struct ArionMerit;
+impl pallet_compute_scoring::MeritSource<AccountId> for ArionMerit {
+	fn registered_miners() -> sp_std::vec::Vec<([u8; 32], AccountId, u128)> {
+		use frame_support::storage::IterableStorageMap;
+		pallet_arion::NodeIdToChild::<Runtime>::iter()
+			.map(|(node_id, child)| {
+				let w = pallet_arion::NodeWeightByChild::<Runtime>::get(&child);
+				(node_id, child, u128::from(w))
+			})
+			.collect()
+	}
+}
+
+parameter_types! {
+	/// Safety cap — a fleet beyond this fails `close_epoch` closed rather
+	/// than silently skip (which would zero the skipped miners' score).
+	pub const MaxMinersPerEpochClose: u32 = 5_000;
+}
+
+impl pallet_compute_scoring::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	// The same validator/council authority that drives Arion's weights.
+	type AuthorityOrigin = frame_system::EnsureSignedBy<ArionAdminMembers, AccountId>;
+	type Merit = ArionMerit;
+	type MaxMinersPerEpochClose = MaxMinersPerEpochClose;
+	type WeightInfo = pallet_compute_scoring::weights::SubstrateWeight<Runtime>;
+}
+
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -1970,6 +2005,10 @@ construct_runtime!(
 		// IpfsPallet: ipfs_pallet = 75,
 		Arion: pallet_arion = 76,
 		PalletCalendar: pallet_calendar = 78,
+		// The name MUST be `ComputeScoring` — the hippius-compute
+		// `read-miner-status` reader hashes `twox_128("ComputeScoring")`
+		// for every storage key it decodes.
+		ComputeScoring: pallet_compute_scoring = 79,
 	}
 );
 


### PR DESCRIPTION
New `pallet-compute-scoring` (runtime name `ComputeScoring` = 79) giving the hippius-compute §23 scheduler the on-chain score/rank/status signal its `read-miner-status` reader decodes — which previously matched no pallet (read zero miners, no merit rank).

- Storage byte-matched to the reader's frozen contract (MinerStatusEntry head=status/tail=epoch; EpochWeights double-map (u64,[u8;32])->u128; sparse MinerStatuses). tests.rs re-asserts the exact layouts.
- close_epoch (authority-gated) snapshots Arion's deployed NodeWeightByChild into EpochWeights[next][node_id] + bumps CurrentEpoch (no new merit math; Arion stays the source of truth).
- set_miner_status (authority-gated) drives the §13 Active/Quarantined/Decommissioned machine; Active clears the row.
- Decoupled from Arion via a MeritSource trait the runtime wires (ArionMerit).

cargo test -p pallet-compute-scoring -> 10 pass (incl. byte-layout conformance). cargo check -p hippius-mainnet-runtime -> green.

Follow-ups: a migration seeding CurrentEpoch + back-filling EpochWeights[current] from Arion before the runtime upgrade; a linear close_epoch benchmark with a populated fleet.

Generated with Claude Code.