### PR TITLE
fix: migrate vali-weights-submitter to bittensor SDK v11

### DIFF
--- a/vali-weights-submitter/mnemonic_wallet_helper.py
+++ b/vali-weights-submitter/mnemonic_wallet_helper.py
@@ -70,10 +70,12 @@ def test_mnemonic_wallet():
     if wallet:
         # Test connection to Bittensor
         try:
-            subtensor = bt.subtensor(network=config['bittensor']['chain_endpoint'])
-            balance = subtensor.get_balance(wallet.hotkey.ss58_address)
+            # bittensor v11: blocking Subtensor, balances namespace, close optional
+            subtensor = bt.Subtensor(network=config['bittensor']['chain_endpoint'])
+            balance = subtensor.balances.get(wallet.hotkey.ss58_address)
             print(f"✓ Wallet balance: {balance} TAO")
-            subtensor.close()
+            if hasattr(subtensor, "close"):
+                subtensor.close()
         except Exception as e:
             print(f"✗ Error checking balance: {e}")
 

--- a/vali-weights-submitter/requirements.txt
+++ b/vali-weights-submitter/requirements.txt
@@ -1,4 +1,4 @@
-bittensor>=9.10.0
+bittensor>=11.0.0
 substrate-interface>=1.7.0,<2.0.0
 pyyaml>=6.0
 numpy>=1.21.0

--- a/vali-weights-submitter/run_continuous.py
+++ b/vali-weights-submitter/run_continuous.py
@@ -49,7 +49,8 @@ class ContinuousWeightSubmitter:
         """Initialize Bittensor connection for block monitoring."""
         import bittensor as bt
         
-        self.subtensor = bt.subtensor(
+        # bittensor v11: bt.Subtensor is blocking when called directly
+        self.subtensor = bt.Subtensor(
             network=self.config['bittensor']['chain_endpoint']
         )
         self.logger.info("Initialized Bittensor connection for block monitoring")
@@ -73,7 +74,8 @@ class ContinuousWeightSubmitter:
             await self.initialize_subtensor()
         
         try:
-            block_number = self.subtensor.block
+            # bittensor v11: block is a method, not a property
+            block_number = self.subtensor.block()
             return block_number
         except Exception as e:
             self.logger.error(f"Error getting current block: {e}")
@@ -192,7 +194,8 @@ class ContinuousWeightSubmitter:
         """Stop the continuous submission process."""
         self.running = False
         self.logger.info("Stopping continuous weight submission...")
-        if self.subtensor:
+        # bittensor v11: close() is optional (auto on GC) and may not exist
+        if self.subtensor and hasattr(self.subtensor, "close"):
             self.subtensor.close()
 
 

--- a/vali-weights-submitter/setup_wallet.py
+++ b/vali-weights-submitter/setup_wallet.py
@@ -3,7 +3,7 @@
 Setup script to create a local wallet for weight submission
 """
 
-import bittensor as bt
+from bittensor.wallet import Wallet
 import os
 
 def setup_wallet():
@@ -41,7 +41,7 @@ def setup_wallet():
         print("Wallet location: ~/.bittensor/wallets/default/")
         
         # Load and display wallet info
-        wallet = bt.wallet(name="default", hotkey="default")
+        wallet = Wallet(name="default", hotkey="default")
         print(f"Hotkey SS58 address: {wallet.hotkey.ss58_address}")
         
         return True

--- a/vali-weights-submitter/sync_metagraph.py
+++ b/vali-weights-submitter/sync_metagraph.py
@@ -108,7 +108,8 @@ class StorageMonitor:
 
                 logger.info(f"Connecting to Bittensor chain using Bittensor library...")
                 # Use Bittensor library for Bittensor connection (same as run_continuous.py)
-                self.bittensor_chain = bt.subtensor(network="finney")  # Use mainnet
+                # bittensor v11: bt.Subtensor is blocking when called directly
+                self.bittensor_chain = bt.Subtensor(network="finney")  # Use mainnet
                 logger.info("✅ Connected to Bittensor chain using Bittensor library")
 
                 return True
@@ -170,25 +171,20 @@ class StorageMonitor:
     def get_uids_from_bittensor(self):
         """Fetch UIDs from Bittensor chain for net_uid 75"""
         try:
-            # Use Bittensor library's metagraph method (same as run_continuous.py)
-            metagraph = bt.metagraph(
-                netuid=self.net_uid,
-                subtensor=self.bittensor_chain
-            )
-            
-            # Get active neurons
-            active_neurons = metagraph.neurons
-            
+            # bittensor v11: metagraph lives under subnets namespace, neurons are typed records
+            metagraph = self.bittensor_chain.subnets.metagraph(netuid=self.net_uid)
+
             # Create mapping of UID to hotkey
+            # Note: no axon filter — subnet 75 miners don't serve axons, and the
+            # legacy code's `axon_info.ip != 0` check was a no-op (ip was a str)
             uids = []
-            for uid, neuron in enumerate(active_neurons):
-                if neuron.axon_info.ip != 0:  # Active neuron
-                    uids.append({
-                        "address": neuron.axon_info.hotkey,
-                        "id": uid,
-                        "role": "None",
-                        "substrate_address": neuron.axon_info.hotkey
-                    })
+            for neuron in metagraph:
+                uids.append({
+                    "address": neuron.hotkey,
+                    "id": neuron.uid,
+                    "role": "None",
+                    "substrate_address": neuron.hotkey
+                })
             
             logger.info(f"Fetched {len(uids)} active UIDs from Bittensor")
             return uids
@@ -200,17 +196,16 @@ class StorageMonitor:
     def get_dividends_from_bittensor(self):
         """Fetch dividends from Bittensor chain for net_uid 75"""
         try:
-            # Use Bittensor library's metagraph method to get dividends
-            metagraph = bt.metagraph(
-                netuid=self.net_uid,
-                subtensor=self.bittensor_chain
-            )
-            
-            # Get dividends from the metagraph
-            dividends = metagraph.dividends
-            if dividends is not None:
+            # bittensor v11: dividends are per-neuron fields, rebuild the uid-indexed list
+            metagraph = self.bittensor_chain.subnets.metagraph(netuid=self.net_uid)
+
+            neurons = list(metagraph)
+            if neurons:
+                dividends = [0.0] * (max(n.uid for n in neurons) + 1)
+                for n in neurons:
+                    dividends[n.uid] = float(n.dividends)
                 logger.info(f"Fetched {len(dividends)} dividends from Bittensor")
-                return list(dividends)
+                return dividends
             else:
                 logger.warning("No dividends found in metagraph")
                 return []

--- a/vali-weights-submitter/weight_submitter.py
+++ b/vali-weights-submitter/weight_submitter.py
@@ -19,7 +19,7 @@ os.environ['SSL_CERT_FILE'] = certifi.where()
 os.environ['SSL_CERT_DIR'] = certifi.where()
 
 import bittensor as bt
-from bittensor.core.extrinsics.set_weights import set_weights_extrinsic
+from bittensor.wallet import Wallet
 from substrateinterface import SubstrateInterface, Keypair
 
 
@@ -57,8 +57,8 @@ class WeightSubmitter:
         """Initialize connections to Bittensor and Hippius chain."""
         self.logger.info("Initializing connections...")
         
-        # Initialize Bittensor subtensor
-        self.subtensor = bt.subtensor(
+        # Initialize Bittensor subtensor (v11: blocking when called directly)
+        self.subtensor = bt.Subtensor(
             network=self.config['bittensor']['chain_endpoint']
         )
         
@@ -99,7 +99,7 @@ class WeightSubmitter:
         else:
             # Use local wallet files
             try:
-                self.wallet = bt.wallet(
+                self.wallet = Wallet(
                     name=self.config['wallet']['name'],
                     hotkey=self.config['wallet']['hotkey'],
                     path=self.config['wallet']['path']
@@ -134,20 +134,15 @@ class WeightSubmitter:
         self.logger.info(f"Fetching metagraph for subnet {self.config['bittensor']['subnet_id']}...")
         
         try:
-            # Get metagraph for the subnet
-            metagraph = bt.metagraph(
-                netuid=self.config['bittensor']['subnet_id'],
-                subtensor=self.subtensor
+            # v11: metagraph lives under the subnets namespace, neurons are typed records
+            metagraph = self.subtensor.subnets.metagraph(
+                netuid=self.config['bittensor']['subnet_id']
             )
-            
-            # Get active neurons
-            active_neurons = metagraph.neurons
-            
+
             # Create mapping of UID to hotkey
-            uid_to_hotkey = {}
-            for uid, neuron in enumerate(active_neurons):
-                if neuron.axon_info.ip != 0:  # Active neuron
-                    uid_to_hotkey[uid] = neuron.axon_info.hotkey
+            # Note: no axon filter — subnet 75 miners don't serve axons, and the
+            # legacy code's `axon_info.ip != 0` check was a no-op (ip was a str)
+            uid_to_hotkey = {neuron.uid: neuron.hotkey for neuron in metagraph}
             
             self.logger.info(f"Found {len(uid_to_hotkey)} active neurons in subnet {self.config['bittensor']['subnet_id']}")
             return uid_to_hotkey
@@ -346,20 +341,23 @@ class WeightSubmitter:
                 success = result.is_success
                 
             else:
-                # Local wallet - use Bittensor's set_weights_extrinsic
+                # Local wallet - v11: submit via SetWeights intent (normalization handled by SDK)
                 self.logger.info(f"Submitting weights using local wallet: {self.wallet.hotkey.ss58_address}")
-                
-                success = set_weights_extrinsic(
-                    subtensor=self.subtensor,
-                    wallet=self.wallet,
-                    netuid=self.config['bittensor']['subnet_id'],
-                    uids=uids_array,
-                    weights=weights_array,
-                    version_key=self.config['weights']['version_key'],
+
+                result = self.subtensor.execute(
+                    bt.SetWeights(
+                        netuid=self.config['bittensor']['subnet_id'],
+                        weights={uid: float(weight) for uid, weight in matched_weights},
+                        version_key=self.config['weights']['version_key']
+                    ),
+                    self.wallet,
                     wait_for_inclusion=self.config['weights']['wait_for_inclusion'],
                     wait_for_finalization=self.config['weights']['wait_for_finalization'],
                     period=self.config['weights']['period']
                 )
+                success = result.success
+                if not success and result.error is not None:
+                    self.logger.error(f"SetWeights failed: {result.error.name} - {result.error.remediation}")
             
             if success:
                 self.logger.info("Weights submitted successfully")
@@ -457,8 +455,8 @@ class WeightSubmitter:
             self.logger.error(f"Error in main execution: {e}")
             return False
         finally:
-            # Clean up connections
-            if self.subtensor:
+            # Clean up connections (v11: subtensor close is optional, auto on GC)
+            if self.subtensor and hasattr(self.subtensor, "close"):
                 self.subtensor.close()
             if self.hippius_interface:
                 self.hippius_interface.close()

--- a/vali-weights-submitter/weight_submitter_ss58_only.py
+++ b/vali-weights-submitter/weight_submitter_ss58_only.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Tuple, Optional
 import time
 
 import bittensor as bt
-from bittensor.core.extrinsics.set_weights import set_weights_extrinsic
+from bittensor.wallet import Wallet
 from substrateinterface import SubstrateInterface, Keypair
 
 
@@ -50,8 +50,8 @@ class WeightSubmitterSS58:
         """Initialize connections to Bittensor and Hippius chain."""
         self.logger.info("Initializing connections...")
         
-        # Initialize Bittensor subtensor
-        self.subtensor = bt.subtensor(
+        # Initialize Bittensor subtensor (v11: blocking when called directly)
+        self.subtensor = bt.Subtensor(
             network=self.config['bittensor']['chain_endpoint']
         )
         
@@ -70,7 +70,7 @@ class WeightSubmitterSS58:
             self.logger.info(f"Using SS58 address for querying: {self.validator_ss58}")
             
             # Still need a wallet for weight submission, but we'll use it minimally
-            self.wallet = bt.wallet(
+            self.wallet = Wallet(
                 name=self.config['wallet']['name'],
                 hotkey=self.config['wallet']['hotkey'],
                 path=self.config['wallet']['path']
@@ -78,7 +78,7 @@ class WeightSubmitterSS58:
             self.logger.info(f"Using local wallet for submission: {self.wallet.hotkey.ss58_address}")
         else:
             # Use local wallet for both querying and submission
-            self.wallet = bt.wallet(
+            self.wallet = Wallet(
                 name=self.config['wallet']['name'],
                 hotkey=self.config['wallet']['hotkey'],
                 path=self.config['wallet']['path']
@@ -98,20 +98,15 @@ class WeightSubmitterSS58:
         self.logger.info(f"Fetching metagraph for subnet {self.config['bittensor']['subnet_id']}...")
         
         try:
-            # Get metagraph for the subnet
-            metagraph = bt.metagraph(
-                netuid=self.config['bittensor']['subnet_id'],
-                subtensor=self.subtensor
+            # v11: metagraph lives under the subnets namespace, neurons are typed records
+            metagraph = self.subtensor.subnets.metagraph(
+                netuid=self.config['bittensor']['subnet_id']
             )
-            
-            # Get active neurons
-            active_neurons = metagraph.neurons
-            
+
             # Create mapping of UID to hotkey
-            uid_to_hotkey = {}
-            for uid, neuron in enumerate(active_neurons):
-                if neuron.axon_info.ip != 0:  # Active neuron
-                    uid_to_hotkey[uid] = neuron.axon_info.hotkey
+            # Note: no axon filter — subnet 75 miners don't serve axons, and the
+            # legacy code's `axon_info.ip != 0` check was a no-op (ip was a str)
+            uid_to_hotkey = {neuron.uid: neuron.hotkey for neuron in metagraph}
             
             self.logger.info(f"Found {len(uid_to_hotkey)} active neurons in subnet {self.config['bittensor']['subnet_id']}")
             return uid_to_hotkey
@@ -213,27 +208,21 @@ class WeightSubmitterSS58:
         self.logger.info(f"Submitting weights for {len(matched_weights)} neurons...")
         
         try:
-            # Extract UIDs and weights
-            uids = [uid for uid, _ in matched_weights]
-            weights = [weight for _, weight in matched_weights]
-            
-            # Convert to numpy arrays as expected by the function
-            uids_array = np.array(uids, dtype=np.int64)
-            weights_array = np.array(weights, dtype=np.float32)
-            
-            # Submit weights using the bittensor function
-            # Note: We still need a wallet for submission, but we can use the SS58 for querying
-            success = set_weights_extrinsic(
-                subtensor=self.subtensor,
-                wallet=self.wallet,
-                netuid=self.config['bittensor']['subnet_id'],
-                uids=uids_array,
-                weights=weights_array,
-                version_key=self.config['weights']['version_key'],
+            # v11: submit via SetWeights intent (normalization handled by SDK)
+            result = self.subtensor.execute(
+                bt.SetWeights(
+                    netuid=self.config['bittensor']['subnet_id'],
+                    weights={uid: float(weight) for uid, weight in matched_weights},
+                    version_key=self.config['weights']['version_key']
+                ),
+                self.wallet,
                 wait_for_inclusion=self.config['weights']['wait_for_inclusion'],
                 wait_for_finalization=self.config['weights']['wait_for_finalization'],
                 period=self.config['weights']['period']
             )
+            success = result.success
+            if not success and result.error is not None:
+                self.logger.error(f"SetWeights failed: {result.error.name} - {result.error.remediation}")
             
             if success:
                 self.logger.info("Weights submitted successfully")
@@ -278,8 +267,8 @@ class WeightSubmitterSS58:
             self.logger.error(f"Error in main execution: {e}")
             raise
         finally:
-            # Clean up connections
-            if self.subtensor:
+            # Clean up connections (v11: subtensor close is optional, auto on GC)
+            if self.subtensor and hasattr(self.subtensor, "close"):
                 self.subtensor.close()
             if self.hippius_interface:
                 self.hippius_interface.close()


### PR DESCRIPTION
## Summary
- `bt.subtensor` / `bt.metagraph` were removed in bittensor v11 — migrated to `bt.Subtensor` (blocking directly, async when awaited) and `subtensor.subnets.metagraph(netuid)` with typed per-neuron records
- Replaced removed `set_weights_extrinsic` import (crashed at module load) with the v11 `SetWeights` intent via `subtensor.execute()` — SDK now handles normalization and u16 quantization internally
- `bt.wallet` → `bittensor.wallet.Wallet`, `get_balance` → `balances.get`, `subtensor.block` property → `block()` method, guarded optional `close()`
- Dropped the legacy axon "active" filter: `axon_info.ip != 0` was a no-op (str vs int comparison) and subnet 75 miners serve no axon — a naive v11 translation would silently return 0 UIDs
- Rebuilt the uid-indexed dividends list from per-neuron fields
- `requirements.txt`: `bittensor>=11.0.0` (requires Python 3.10–3.13)

## Test plan
Verified read-only end-to-end against live endpoints with bittensor 11.0.0 (no weight submission):
- `sync_metagraph.py`: connected to both chains, fetched 256 UIDs + 256 dividends, 12 validators / 244 miners
- `weight_submitter.py`: 256-UID metagraph, 366 Hippius rankings retrieved, 194 matched, normalization OK
- `SetWeights` dict form, `execute()` kwargs (`period`, `wait_for_inclusion`, `wait_for_finalization`) and `ExtrinsicResult` fields verified by introspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)