### PR TITLE
feat: pay Arion storage miners from a new bank pallet (byte-blocks accrual, USD pricing, staked payouts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,6 +4560,7 @@ dependencies = [
  "pallet-babe 37.0.0",
  "pallet-bags-list",
  "pallet-balances 38.0.1",
+ "pallet-bank",
  "pallet-base-fee",
  "pallet-bittensor",
  "pallet-bounties",
@@ -7781,6 +7782,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
  "sp-runtime 39.0.3",
+ "sp-staking 34.0.0",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
 ]
 
@@ -7983,6 +7985,24 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 39.0.3",
+]
+
+[[package]]
+name = "pallet-bank"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking 37.0.0",
+ "frame-support 37.1.0",
+ "frame-system 37.1.0",
+ "log",
+ "pallet-balances 38.0.1",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
+ "sp-io 38.0.0",
+ "sp-keyring 39.0.0",
+ "sp-runtime 39.0.3",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2407)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9035,6 +9035,7 @@ dependencies = [
  "pallet-arion",
  "pallet-assets 39.0.0",
  "pallet-balances 38.0.1",
+ "pallet-bank",
  "pallet-calendar",
  "pallet-credits",
  "pallet-rankings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,6 +359,7 @@ pallet-execution-unit = { path = "pallets/execution-unit", default-features = fa
 pallet-arion  = { path = "pallets/arion-pallet", default-features = false }
 ipfs-pallet  = { path = "pallets/ipfs", default-features = false }
 pallet-alpha-bridge = { path = "pallets/alpha-bridge", default-features = false }
+pallet-bank = { path = "pallets/bank", default-features = false }
 pallet-ip = { path = "pallets/ip", default-features = false }
 pallet-calendar = { path = "pallets/calendar", default-features = false }
 pallet-rankings   = { path = "pallets/ranking", default-features = false }

--- a/pallets/arion-pallet/Cargo.toml
+++ b/pallets/arion-pallet/Cargo.toml
@@ -11,6 +11,7 @@ frame-system  = { workspace = true, default-features = false }
 sp-runtime    = { workspace = true, default-features = false }
 sp-std        = { workspace = true, default-features = false }
 sp-core       = { workspace = true, default-features = false }
+sp-staking    = { workspace = true, default-features = false }
 pallet-registration = { workspace = true, default-features = false }
 pallet-proxy = { workspace = true, default-features = false }
 
@@ -25,6 +26,7 @@ std = [
   "sp-runtime/std",
   "sp-std/std",
   "sp-core/std",
+  "sp-staking/std",
   "pallet-registration/std",
   "pallet-proxy/std",
   "codec/std",

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -19,17 +19,18 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	dispatch::DispatchResult,
 	pallet_prelude::*,
-	traits::{Currency, EnsureOrigin, Get, ReservableCurrency},
-	BoundedVec,
+	traits::{Currency, EnsureOrigin, ExistenceRequirement, Get, ReservableCurrency},
+	BoundedVec, PalletId,
 };
 use frame_system::pallet_prelude::*;
 use scale_info::TypeInfo;
-use sp_core::{ed25519, H256};
+use sp_core::{ed25519, H256, U256};
 use sp_runtime::{
-	traits::{Hash, Saturating, Verify, Zero},
-	RuntimeDebug,
+	traits::{AccountIdConversion, Hash, Saturating, Verify, Zero},
+	RuntimeDebug, SaturatedConversion,
 };
-use sp_std::prelude::*;
+use sp_staking::StakingInterface;
+use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 pub use pallet::*;
 
@@ -88,6 +89,21 @@ pub mod pallet {
 			//     &p.delegate == child &&
 			//     matches!(p.proxy_type, ProxyType::NonTransfer)
 			// })
+		}
+	}
+
+	/// Source of funds for miner payments. Implemented by the bank pallet through
+	/// a runtime-side adapter (no crate coupling), `()` disables payments.
+	pub trait PayoutSource<AccountId, Balance> {
+		/// Ask the source to transfer up to `amount` to `dest` on behalf of
+		/// `requester`. Returns the amount actually transferred (`0` on refusal
+		/// or shortfall — the caller accounts for the difference).
+		fn request_payment(requester: &AccountId, dest: &AccountId, amount: Balance) -> Balance;
+	}
+
+	impl<AccountId, Balance: Zero> PayoutSource<AccountId, Balance> for () {
+		fn request_payment(_: &AccountId, _: &AccountId, _: Balance) -> Balance {
+			Zero::zero()
 		}
 	}
 
@@ -432,7 +448,9 @@ pub mod pallet {
 	}
 
 	/// Aggregate user storage usage metrics reported by validators.
-	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen, Default)]
+	#[derive(
+		Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen, Default,
+	)]
 	pub struct UserStorageUsageUpdate<AccountId> {
 		pub account_id: AccountId,
 		pub file_size: u128,
@@ -685,6 +703,29 @@ pub mod pallet {
 		/// Max `MinerStatsByUid` keys examined per pruning tick (removals are a subset).
 		#[pallet::constant]
 		type MinerStatsPruneMaxScanPerBlock: Get<u32>;
+
+		// --- Miner payments ---
+
+		/// Pallet id from which the arion escrow account (miner payment flow) is derived.
+		#[pallet::constant]
+		type PalletId: Get<PalletId>;
+
+		/// Funding source for miner payments (the bank pallet in the runtime).
+		type PayoutSource: PayoutSource<Self::AccountId, BalanceOf<Self>>;
+
+		/// Staking interface used to lock family payouts as bonded stake.
+		type Staking: sp_staking::StakingInterface<
+			Balance = BalanceOf<Self>,
+			AccountId = Self::AccountId,
+		>;
+
+		/// Current token price in USD, fixed-point 18 decimals
+		/// (`0` = unknown → settlement is skipped, accruals keep accumulating).
+		type TokenPriceUsd: Get<u128>;
+
+		/// Run miner payment settlement every N blocks (`0` = disabled).
+		#[pallet::constant]
+		type SettlementInterval: Get<BlockNumberFor<Self>>;
 	}
 
 	#[pallet::pallet]
@@ -694,18 +735,29 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
-			let interval = T::MinerStatsPruneInterval::get();
-			if interval.is_zero() {
-				return Weight::zero();
+			let mut weight = Weight::zero();
+
+			let prune_interval = T::MinerStatsPruneInterval::get();
+			if !prune_interval.is_zero() && n % prune_interval == Zero::zero() {
+				Self::prune_stale_miner_stats();
+				weight = weight.saturating_add(<T as Config>::WeightInfo::miner_stats_prune_hook(
+					T::MinerStatsPruneMaxScanPerBlock::get(),
+					T::MaxChildrenTotal::get(),
+				));
 			}
-			if n % interval != Zero::zero() {
-				return Weight::zero();
+
+			let settle_interval = T::SettlementInterval::get();
+			if !settle_interval.is_zero() && n % settle_interval == Zero::zero() {
+				Self::settle_miner_payments(n);
+				weight = weight.saturating_add(
+					<T as Config>::WeightInfo::miner_payment_settlement_hook(
+						T::MaxChildrenTotal::get(),
+						T::MaxFamilies::get(),
+					),
+				);
 			}
-			Self::prune_stale_miner_stats();
-			<T as Config>::WeightInfo::miner_stats_prune_hook(
-				T::MinerStatsPruneMaxScanPerBlock::get(),
-				T::MaxChildrenTotal::get(),
-			)
+
+			weight
 		}
 	}
 
@@ -751,6 +803,47 @@ pub mod pallet {
 	/// Last `MinerStatsByUid` key processed by batched pruning (`None` = next pass from the start).
 	#[pallet::storage]
 	pub type MinerStatsPruneCursor<T> = StorageValue<_, u32, OptionQuery>;
+
+	// -------------------------
+	// Miner payment state
+	// -------------------------
+
+	/// Payment accrual for one miner uid: raw shard bytes integrated over blocks.
+	#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	pub struct MinerAccrual<BlockNumber> {
+		/// Σ `shard_data_bytes × elapsed_blocks` since the last settlement.
+		pub byte_blocks: u128,
+		/// Block up to which `byte_blocks` has been accumulated.
+		pub last_block: BlockNumber,
+	}
+
+	/// Why a payment settlement tick did not run.
+	#[derive(Clone, Copy, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	pub enum SettlementSkipReason {
+		/// [`MinerPriceUsdPerGbBlock`] is zero (payments disabled).
+		PriceUnset,
+		/// The token price feed returned zero.
+		TokenPriceUnavailable,
+	}
+
+	/// Price paid to miners, in USD per GiB of raw shard data per block
+	/// (fixed-point, 18 decimals). `0` disables payment settlement entirely.
+	#[pallet::storage]
+	pub type MinerPriceUsdPerGbBlock<T> = StorageValue<_, u128, ValueQuery>;
+
+	/// Payment accrual per miner uid (byte-blocks since the last settlement).
+	#[pallet::storage]
+	pub type MinerAccruals<T: Config> =
+		StorageMap<_, Blake2_128Concat, u32, MinerAccrual<BlockNumberFor<T>>, OptionQuery>;
+
+	/// Tokens owed to a family but not yet paid (carry-over from bank shortfalls).
+	#[pallet::storage]
+	pub type FamilyArrears<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, u128, ValueQuery>;
+
+	/// Last block a payment settlement ran at.
+	#[pallet::storage]
+	pub type LastSettlementBlock<T: Config> = StorageValue<_, BlockNumberFor<T>, OptionQuery>;
 
 	// -------------------------
 	// Attestation state
@@ -1077,6 +1170,28 @@ pub mod pallet {
 			s3_file_size: u128,
 			s3_file_count: u128,
 		},
+		/// Miner payment price was set by admin (USD per GiB per block, 18 decimals).
+		MinerPriceSet {
+			price_usd_per_gb_block: u128,
+		},
+		/// A miner payment settlement completed.
+		MinerPaymentSettled {
+			block: BlockNumberFor<T>,
+			families: u32,
+			tokens_due: u128,
+			tokens_paid: u128,
+		},
+		/// A family received a payout. `staked` is false when bonding failed and
+		/// the amount was left as free balance on the family account.
+		FamilyPaid {
+			family: T::AccountId,
+			tokens: u128,
+			staked: bool,
+		},
+		/// A settlement tick was skipped. Accruals keep accumulating.
+		MinerPaymentSkipped {
+			reason: SettlementSkipReason,
+		},
 	}
 
 	#[pallet::error]
@@ -1235,12 +1350,8 @@ pub mod pallet {
 		}
 
 		fn find_uid_for_node_in_epoch(epoch: u64, node_id: &[u8; 32]) -> Option<u32> {
-			EpochMiners::<T>::get(epoch).and_then(|miners| {
-				miners
-					.iter()
-					.find(|m| m.node_id == *node_id)
-					.map(|m| m.uid)
-			})
+			EpochMiners::<T>::get(epoch)
+				.and_then(|miners| miners.iter().find(|m| m.node_id == *node_id).map(|m| m.uid))
 		}
 
 		/// Uids that still correspond to **active** children (registration + optional CRUSH map).
@@ -1289,6 +1400,7 @@ pub mod pallet {
 				let keep = protected.iter().any(|&p| p == *uid);
 				if !keep {
 					MinerStatsByUid::<T>::remove(uid);
+					MinerAccruals::<T>::remove(uid);
 				}
 			}
 
@@ -1298,6 +1410,154 @@ pub mod pallet {
 			} else {
 				MinerStatsPruneCursor::<T>::put(last);
 			}
+		}
+
+		/// Escrow account funds transit through during payment settlement.
+		pub fn account_id() -> T::AccountId {
+			<T as Config>::PalletId::get().into_account_truncating()
+		}
+
+		/// Integrate the currently stored `shard_data_bytes` of `uid` over the
+		/// blocks elapsed since the last accrual, up to `now`.
+		fn accrue_miner_bytes(uid: u32, now: BlockNumberFor<T>) {
+			let prev_bytes =
+				MinerStatsByUid::<T>::get(uid).map(|s| s.shard_data_bytes).unwrap_or(0);
+			MinerAccruals::<T>::mutate(uid, |acc| {
+				let mut a = acc.take().unwrap_or(MinerAccrual { byte_blocks: 0, last_block: now });
+				let elapsed: u128 = now.saturating_sub(a.last_block).saturated_into::<u128>();
+				a.byte_blocks =
+					a.byte_blocks.saturating_add(crate::accrue_byte_blocks(prev_bytes, elapsed));
+				a.last_block = now;
+				*acc = Some(a);
+			});
+		}
+
+		/// Miner payment settlement: accrue all active children up to `now`,
+		/// aggregate per family, pull funds from the payout source, distribute
+		/// pro-rata on shortfall (delta → [`FamilyArrears`]) and bond each
+		/// payout as stake on the family account.
+		fn settle_miner_payments(now: BlockNumberFor<T>) {
+			let price = MinerPriceUsdPerGbBlock::<T>::get();
+			if price == 0 {
+				Self::deposit_event(Event::MinerPaymentSkipped {
+					reason: SettlementSkipReason::PriceUnset,
+				});
+				return;
+			}
+			let token_price = T::TokenPriceUsd::get();
+			if token_price == 0 {
+				Self::deposit_event(Event::MinerPaymentSkipped {
+					reason: SettlementSkipReason::TokenPriceUnavailable,
+				});
+				return;
+			}
+
+			// Accrue every active child up to `now`, convert and aggregate per family.
+			let mut family_due: BTreeMap<T::AccountId, u128> = BTreeMap::new();
+			for (child, reg) in ChildRegistrations::<T>::iter() {
+				if reg.status != ChildStatus::Active {
+					continue;
+				}
+				let Some(uid) = ChildMinerUid::<T>::get(&child) else {
+					continue;
+				};
+				if uid == 0 {
+					continue;
+				}
+				Self::accrue_miner_bytes(uid, now);
+				let byte_blocks = MinerAccruals::<T>::mutate(uid, |acc| {
+					acc.as_mut().map(|a| core::mem::take(&mut a.byte_blocks)).unwrap_or(0)
+				});
+				if byte_blocks == 0 {
+					continue;
+				}
+				let tokens = crate::tokens_for_byte_blocks(byte_blocks, price, token_price);
+				if tokens == 0 {
+					continue;
+				}
+				family_due
+					.entry(reg.family.clone())
+					.and_modify(|d| *d = d.saturating_add(tokens))
+					.or_insert(tokens);
+			}
+
+			// Include arrears carried over from previous shortfalls.
+			for (family, owed) in FamilyArrears::<T>::iter() {
+				if owed > 0 {
+					family_due
+						.entry(family)
+						.and_modify(|d| *d = d.saturating_add(owed))
+						.or_insert(owed);
+				}
+			}
+
+			let total_due: u128 = family_due.values().fold(0u128, |a, v| a.saturating_add(*v));
+			if total_due == 0 {
+				LastSettlementBlock::<T>::put(now);
+				return;
+			}
+
+			// Pull funds from the bank into the arion escrow account.
+			let escrow = Self::account_id();
+			let requested: BalanceOf<T> = total_due.saturated_into();
+			let paid_balance = T::PayoutSource::request_payment(&escrow, &escrow, requested);
+			let total_paid: u128 = paid_balance.saturated_into::<u128>();
+
+			let mut families = 0u32;
+			let mut tokens_paid_sum = 0u128;
+			for (family, due) in family_due.iter() {
+				// Pro-rata split when the bank could not cover everything.
+				let pay = if total_paid >= total_due {
+					*due
+				} else {
+					// total_due > 0 checked above
+					(U256::from(*due) * U256::from(total_paid) / U256::from(total_due)).as_u128()
+				};
+				let arrears = due.saturating_sub(pay);
+				if arrears > 0 {
+					FamilyArrears::<T>::insert(family, arrears);
+				} else {
+					FamilyArrears::<T>::remove(family);
+				}
+				if pay == 0 {
+					continue;
+				}
+				let amount: BalanceOf<T> = pay.saturated_into();
+				if T::DepositCurrency::transfer(
+					&escrow,
+					family,
+					amount,
+					ExistenceRequirement::AllowDeath,
+				)
+				.is_err()
+				{
+					// Funds stay in escrow; owe the family for the next round.
+					FamilyArrears::<T>::mutate(family, |a| *a = a.saturating_add(pay));
+					continue;
+				}
+				// Lock the payout as stake. On failure the tokens remain as free
+				// balance on the family account — never roll back the payment.
+				let staked = if T::Staking::stake(family).is_ok() {
+					T::Staking::bond_extra(family, amount).is_ok()
+				} else {
+					T::Staking::bond(family, amount, family).is_ok()
+				};
+				families = families.saturating_add(1);
+				tokens_paid_sum = tokens_paid_sum.saturating_add(pay);
+				Self::deposit_event(Event::FamilyPaid {
+					family: family.clone(),
+					tokens: pay,
+					staked,
+				});
+			}
+
+			LastSettlementBlock::<T>::put(now);
+			Self::deposit_event(Event::MinerPaymentSettled {
+				block: now,
+				families,
+				tokens_due: total_due,
+				tokens_paid: tokens_paid_sum,
+			});
 		}
 
 		/// Remove per-child weight / quality tracking (avoids stale keys after deregistration).
@@ -1827,7 +2087,11 @@ pub mod pallet {
 			let cur = CurrentStatsBucket::<T>::get();
 			ensure!(bucket >= cur, Error::<T>::StatsBucketRegression);
 
+			let now = Self::now();
 			for u in updates.iter() {
+				// Integrate the *previous* stored bytes over the elapsed blocks
+				// before overwriting them — payment accrual (byte-blocks).
+				Self::accrue_miner_bytes(u.uid, now);
 				MinerStatsByUid::<T>::insert(u.uid, u.stats.clone());
 			}
 			CurrentStatsBucket::<T>::put(bucket);
@@ -1836,6 +2100,20 @@ pub mod pallet {
 			}
 
 			Self::deposit_event(Event::MinerStatsUpdated { bucket, updates: updates.len() as u32 });
+			Ok(())
+		}
+
+		/// Set the price paid to miners, in USD per GiB of raw shard data per
+		/// block (fixed-point, 18 decimals). `0` disables payment settlement.
+		#[pallet::call_index(4)]
+		#[pallet::weight((<T as pallet::Config>::WeightInfo::set_miner_price(), Pays::No))]
+		pub fn set_miner_price(
+			origin: OriginFor<T>,
+			price_usd_per_gb_block: u128,
+		) -> DispatchResult {
+			T::ArionAdminOrigin::ensure_origin(origin)?;
+			MinerPriceUsdPerGbBlock::<T>::put(price_usd_per_gb_block);
+			Self::deposit_event(Event::MinerPriceSet { price_usd_per_gb_block });
 			Ok(())
 		}
 
@@ -2668,12 +2946,94 @@ pub mod pallet {
 				e = e.saturating_add(1);
 			}
 
-			Self::deposit_event(Event::CrushEpochsPruned {
-				start_epoch,
-				pruned,
-				next_epoch: e,
-			});
+			Self::deposit_event(Event::CrushEpochsPruned { start_epoch, pruned, next_epoch: e });
 			Ok(())
 		}
+	}
+}
+
+/// Pure payment math — kept outside the pallet so it can be unit-tested
+/// without a mock runtime.
+///
+/// Byte-blocks accumulated by holding `prev_bytes` for `elapsed_blocks`.
+pub fn accrue_byte_blocks(prev_bytes: u128, elapsed_blocks: u128) -> u128 {
+	prev_bytes.saturating_mul(elapsed_blocks)
+}
+
+/// Tokens owed for `byte_blocks`, given a price in USD per GiB per block and a
+/// token price in USD (both fixed-point 18 decimals). Deterministic integer
+/// math via `U256`, saturating at `u128::MAX`.
+///
+/// `tokens = byte_blocks × price × 10^18 / (2^30 × token_price)`
+pub fn tokens_for_byte_blocks(
+	byte_blocks: u128,
+	price_usd_per_gb_block: u128,
+	token_price_usd: u128,
+) -> u128 {
+	if token_price_usd == 0 {
+		return 0;
+	}
+	let num = U256::from(byte_blocks)
+		.saturating_mul(U256::from(price_usd_per_gb_block))
+		.saturating_mul(U256::from(1_000_000_000_000_000_000_u128));
+	let den = U256::from(1_u128 << 30).saturating_mul(U256::from(token_price_usd));
+	let out = num / den;
+	if out > U256::from(u128::MAX) {
+		u128::MAX
+	} else {
+		out.as_u128()
+	}
+}
+
+#[cfg(test)]
+mod payment_math_tests {
+	use super::{accrue_byte_blocks, tokens_for_byte_blocks};
+
+	const USD: u128 = 1_000_000_000_000_000_000; // 18 decimals
+	const GIB: u128 = 1 << 30;
+
+	#[test]
+	fn accrue_is_bytes_times_blocks() {
+		assert_eq!(accrue_byte_blocks(0, 100), 0);
+		assert_eq!(accrue_byte_blocks(GIB, 0), 0);
+		assert_eq!(accrue_byte_blocks(GIB, 100), GIB * 100);
+		// saturates instead of overflowing
+		assert_eq!(accrue_byte_blocks(u128::MAX, 2), u128::MAX);
+	}
+
+	#[test]
+	fn one_gib_block_at_one_usd_each_is_one_token() {
+		// 1 GiB held for 1 block, $1 per GiB-block, token at $1 → exactly 1 token.
+		assert_eq!(tokens_for_byte_blocks(GIB, USD, USD), USD);
+	}
+
+	#[test]
+	fn scales_linearly_with_bytes_price_and_token_price() {
+		// 100 GiB-blocks at $2/GiB-block with token at $4 → 50 tokens.
+		assert_eq!(tokens_for_byte_blocks(100 * GIB, 2 * USD, 4 * USD), 50 * USD);
+		// Sub-GiB amounts round down deterministically.
+		assert_eq!(tokens_for_byte_blocks(GIB / 2, USD, USD), USD / 2);
+	}
+
+	#[test]
+	fn realistic_magnitudes_do_not_overflow() {
+		// 100 TiB held for one day of 6s blocks (14_400), price $0.000_000_01
+		// per GiB-block, token at $0.05.
+		let byte_blocks = 100 * 1024 * GIB * 14_400;
+		let price = USD / 100_000_000;
+		let token_price = USD / 20;
+		let tokens = tokens_for_byte_blocks(byte_blocks, price, token_price);
+		// 102_400 GiB × 14_400 blocks × 1e-8 $ / 0.05 $ ≈ 294.9 tokens
+		assert_eq!(tokens, 294_912 * USD / 1_000);
+	}
+
+	#[test]
+	fn zero_token_price_pays_zero() {
+		assert_eq!(tokens_for_byte_blocks(GIB, USD, 0), 0);
+	}
+
+	#[test]
+	fn extreme_inputs_saturate_at_u128_max() {
+		assert_eq!(tokens_for_byte_blocks(u128::MAX, u128::MAX, 1), u128::MAX);
 	}
 }

--- a/pallets/arion-pallet/src/weights.rs
+++ b/pallets/arion-pallet/src/weights.rs
@@ -50,6 +50,9 @@ pub trait WeightInfo {
     fn update_user_file_size() -> Weight;
     /// `on_initialize` miner stats prune: bounded scan + protected-uid pass over registrations.
     fn miner_stats_prune_hook(max_scan: u32, max_children_total: u32) -> Weight;
+    fn set_miner_price() -> Weight;
+    /// `on_initialize` payment settlement: accrue + aggregate per family + transfer + bond.
+    fn miner_payment_settlement_hook(max_children_total: u32, max_families: u32) -> Weight;
 }
 
 /// Weights for pallet_arion using the Substrate node and recommended hardware.
@@ -72,17 +75,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     }
 
     /// Storage: Arion LastStatsBucket (r:1 w:1)
-    /// Storage: Arion MinerStats (r:0 w:n)
+    /// Storage: Arion MinerStats (r:n w:n) — read for payment accrual, then overwritten
+    /// Storage: Arion MinerAccruals (r:n w:n)
     /// Storage: Arion TotalShards (r:1 w:1)
     /// Storage: Arion TotalBandwidthBytes (r:1 w:1)
     fn submit_miner_stats(n: u32) -> Weight {
         // Base: read/write aggregate state
-        // Per miner: write stats entry
+        // Per miner: accrue byte-blocks + write stats entry
         Weight::from_parts(15_000_000, 0)
             .saturating_add(Weight::from_parts(2_000_000, 0).saturating_mul(n.into()))
             .saturating_add(T::DbWeight::get().reads(3))
             .saturating_add(T::DbWeight::get().writes(3))
-            .saturating_add(T::DbWeight::get().writes(n.into()))
+            .saturating_add(T::DbWeight::get().reads((n as u64).saturating_mul(2)))
+            .saturating_add(T::DbWeight::get().writes((n as u64).saturating_mul(2)))
     }
 
     /// Storage: Arion CurrentWeightBucket (r:1 w:1)
@@ -240,6 +245,24 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(scan.saturating_add(reg_reads)))
             .saturating_add(T::DbWeight::get().writes(scan))
     }
+
+    /// Storage: Arion MinerPriceUsdPerGbBlock (r:0 w:1)
+    fn set_miner_price() -> Weight {
+        Weight::from_parts(10_000_000, 0).saturating_add(T::DbWeight::get().writes(1))
+    }
+
+    /// Per child: ChildRegistrations + ChildMinerUid + MinerStatsByUid reads, MinerAccruals r/w.
+    /// Per family: arrears r/w, balance transfer, staking ledger read + bond write.
+    fn miner_payment_settlement_hook(max_children_total: u32, max_families: u32) -> Weight {
+        let children = max_children_total as u64;
+        let families = max_families as u64;
+        Weight::from_parts(25_000_000, 0)
+            .saturating_add(Weight::from_parts(150_000_000, 0).saturating_mul(families.into()))
+            .saturating_add(T::DbWeight::get().reads(children.saturating_mul(4).saturating_add(2)))
+            .saturating_add(T::DbWeight::get().writes(children))
+            .saturating_add(T::DbWeight::get().reads(families.saturating_mul(4)))
+            .saturating_add(T::DbWeight::get().writes(families.saturating_mul(6)))
+    }
 }
 
 /// For backwards compatibility and testnets
@@ -256,7 +279,8 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_parts(2_000_000, 0).saturating_mul(n.into()))
             .saturating_add(RocksDbWeight::get().reads(3))
             .saturating_add(RocksDbWeight::get().writes(3))
-            .saturating_add(RocksDbWeight::get().writes(n.into()))
+            .saturating_add(RocksDbWeight::get().reads((n as u64).saturating_mul(2)))
+            .saturating_add(RocksDbWeight::get().writes((n as u64).saturating_mul(2)))
     }
 
     fn submit_node_quality(n: u32) -> Weight {
@@ -359,5 +383,20 @@ impl WeightInfo for () {
         Weight::from_parts(20_000_000, 0)
             .saturating_add(RocksDbWeight::get().reads(scan.saturating_add(reg_reads)))
             .saturating_add(RocksDbWeight::get().writes(scan))
+    }
+
+    fn set_miner_price() -> Weight {
+        Weight::from_parts(10_000_000, 0).saturating_add(RocksDbWeight::get().writes(1))
+    }
+
+    fn miner_payment_settlement_hook(max_children_total: u32, max_families: u32) -> Weight {
+        let children = max_children_total as u64;
+        let families = max_families as u64;
+        Weight::from_parts(25_000_000, 0)
+            .saturating_add(Weight::from_parts(150_000_000, 0).saturating_mul(families.into()))
+            .saturating_add(RocksDbWeight::get().reads(children.saturating_mul(4).saturating_add(2)))
+            .saturating_add(RocksDbWeight::get().writes(children))
+            .saturating_add(RocksDbWeight::get().reads(families.saturating_mul(4)))
+            .saturating_add(RocksDbWeight::get().writes(families.saturating_mul(6)))
     }
 }

--- a/pallets/bank/Cargo.toml
+++ b/pallets/bank/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "pallet-bank"
+description = "Bank pallet holding funds used to pay Arion storage miners"
+version = "0.1.0"
+license = "Unlicense"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+publish = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { features = [ "derive", ], workspace = true }
+scale-info = { features = [ "derive", ], workspace = true }
+frame-benchmarking = { optional = true, workspace = true }
+frame-support.workspace = true
+frame-system.workspace = true
+sp-std = { workspace = true, default-features = false }
+sp-core = { workspace = true, default-features = false }
+sp-runtime = { workspace = true, default-features = false }
+log = { version = "0.4.22", default-features = false }
+
+[dev-dependencies]
+sp-io = { workspace = true, default-features = false, features = ["std"] }
+pallet-balances = { workspace = true, default-features = false, features = ["std"] }
+sp-keyring = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "scale-info/std",
+    "frame-benchmarking?/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-std/std",
+    "sp-runtime/std",
+    "sp-core/std",
+]
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+]

--- a/pallets/bank/src/lib.rs
+++ b/pallets/bank/src/lib.rs
@@ -133,16 +133,7 @@ pub mod pallet {
 			deposit_type: DepositType,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
-			T::Currency::transfer(
-				&who,
-				&Self::account_id(),
-				amount,
-				ExistenceRequirement::KeepAlive,
-			)?;
-			TotalDeposited::<T>::mutate(deposit_type, |t| *t = t.saturating_add(amount));
-			Self::deposit_event(Event::Deposited { who, amount, deposit_type });
-			Ok(())
+			Self::deposit_from(&who, amount, deposit_type)
 		}
 
 		/// Add an account to the requester whitelist.
@@ -175,6 +166,26 @@ pub mod pallet {
 		/// The bank sovereign account.
 		pub fn account_id() -> T::AccountId {
 			T::PalletId::get().into_account_truncating()
+		}
+
+		/// Transfer `amount` from `who` into the bank and record it. Shared by
+		/// the `deposit` extrinsic and other pallets (e.g. the marketplace
+		/// routing deposit alpha backing to the bank).
+		pub fn deposit_from(
+			who: &T::AccountId,
+			amount: BalanceOf<T>,
+			deposit_type: DepositType,
+		) -> DispatchResult {
+			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
+			T::Currency::transfer(
+				who,
+				&Self::account_id(),
+				amount,
+				ExistenceRequirement::KeepAlive,
+			)?;
+			TotalDeposited::<T>::mutate(deposit_type, |t| *t = t.saturating_add(amount));
+			Self::deposit_event(Event::Deposited { who: who.clone(), amount, deposit_type });
+			Ok(())
 		}
 
 		/// Free balance held by the bank.

--- a/pallets/bank/src/lib.rs
+++ b/pallets/bank/src/lib.rs
@@ -61,10 +61,9 @@ pub mod pallet {
 	/// Source of deposited funds.
 	#[derive(Clone, Copy, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 	pub enum DepositType {
-		/// Revenue collected from storage users.
-		StorageRevenue,
-		/// Revenue collected from compute users.
-		ComputeRevenue,
+		/// Revenue collected through the marketplace (credits deposits,
+		/// subscriptions) — storage and compute are not distinguishable there.
+		MarketplaceRevenue,
 		/// Protocol emissions.
 		Emission,
 		/// One-off grant / treasury top-up.

--- a/pallets/bank/src/lib.rs
+++ b/pallets/bank/src/lib.rs
@@ -1,0 +1,222 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # Bank Pallet
+//!
+//! Holds the funds used to pay Arion storage miners.
+//!
+//! - `deposit(amount, deposit_type)`: anyone can fund the bank sovereign account,
+//!   tagging the deposit with its source (`DepositType`).
+//! - `request_payment(requester, dest, amount)`: internal API (not an extrinsic) —
+//!   only whitelisted requester accounts (e.g. the Arion pallet sovereign account)
+//!   can pull funds. Pays out at most the available balance and returns the amount
+//!   actually paid; the caller is responsible for handling shortfalls.
+//! - `add_requester` / `remove_requester`: admin-gated whitelist management.
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+pub mod weights;
+
+pub use pallet::*;
+pub use weights::WeightInfo;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use crate::weights::WeightInfo;
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{Currency, ExistenceRequirement, Get},
+		PalletId,
+	};
+	use frame_system::pallet_prelude::*;
+	use sp_runtime::traits::{AccountIdConversion, Saturating, Zero};
+
+	pub type BalanceOf<T> =
+		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Currency held and paid out by the bank.
+		type Currency: Currency<Self::AccountId>;
+
+		/// Pallet id from which the bank sovereign account is derived.
+		#[pallet::constant]
+		type PalletId: Get<PalletId>;
+
+		/// Origin allowed to manage the requester whitelist.
+		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		type WeightInfo: WeightInfo;
+	}
+
+	/// Source of deposited funds.
+	#[derive(Clone, Copy, Encode, Decode, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+	pub enum DepositType {
+		/// Revenue collected from storage users.
+		StorageRevenue,
+		/// Revenue collected from compute users.
+		ComputeRevenue,
+		/// Protocol emissions.
+		Emission,
+		/// One-off grant / treasury top-up.
+		Grant,
+		/// Anything else.
+		Other,
+	}
+
+	/// Accounts allowed to call `request_payment`.
+	#[pallet::storage]
+	pub type WhitelistedRequesters<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
+
+	/// Lifetime total deposited, per deposit type.
+	#[pallet::storage]
+	pub type TotalDeposited<T: Config> =
+		StorageMap<_, Blake2_128Concat, DepositType, BalanceOf<T>, ValueQuery>;
+
+	/// Lifetime total released through `request_payment`.
+	#[pallet::storage]
+	pub type TotalPaidOut<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+	/// Lifetime total released per requester (e.g. arion vs compute escrow).
+	#[pallet::storage]
+	pub type TotalPaidByRequester<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::AccountId, BalanceOf<T>, ValueQuery>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Funds were deposited into the bank.
+		Deposited { who: T::AccountId, amount: BalanceOf<T>, deposit_type: DepositType },
+		/// An account was added to the requester whitelist.
+		RequesterAdded { who: T::AccountId },
+		/// An account was removed from the requester whitelist.
+		RequesterRemoved { who: T::AccountId },
+		/// A payment was released to `dest`. `paid` may be lower than `requested`
+		/// when the bank balance is insufficient.
+		PaymentReleased {
+			requester: T::AccountId,
+			dest: T::AccountId,
+			requested: BalanceOf<T>,
+			paid: BalanceOf<T>,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The caller of `request_payment` is not whitelisted.
+		RequesterNotWhitelisted,
+		/// Amount must be non-zero.
+		ZeroAmount,
+		/// Account is already whitelisted.
+		AlreadyWhitelisted,
+		/// Account is not in the whitelist.
+		NotWhitelisted,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Deposit funds into the bank, tagged with their source type.
+		#[pallet::call_index(0)]
+		#[pallet::weight(<T as Config>::WeightInfo::deposit())]
+		pub fn deposit(
+			origin: OriginFor<T>,
+			amount: BalanceOf<T>,
+			deposit_type: DepositType,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
+			T::Currency::transfer(
+				&who,
+				&Self::account_id(),
+				amount,
+				ExistenceRequirement::KeepAlive,
+			)?;
+			TotalDeposited::<T>::mutate(deposit_type, |t| *t = t.saturating_add(amount));
+			Self::deposit_event(Event::Deposited { who, amount, deposit_type });
+			Ok(())
+		}
+
+		/// Add an account to the requester whitelist.
+		#[pallet::call_index(1)]
+		#[pallet::weight(<T as Config>::WeightInfo::add_requester())]
+		pub fn add_requester(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
+			T::AdminOrigin::ensure_origin(origin)?;
+			ensure!(
+				!WhitelistedRequesters::<T>::contains_key(&who),
+				Error::<T>::AlreadyWhitelisted
+			);
+			WhitelistedRequesters::<T>::insert(&who, ());
+			Self::deposit_event(Event::RequesterAdded { who });
+			Ok(())
+		}
+
+		/// Remove an account from the requester whitelist.
+		#[pallet::call_index(2)]
+		#[pallet::weight(<T as Config>::WeightInfo::remove_requester())]
+		pub fn remove_requester(origin: OriginFor<T>, who: T::AccountId) -> DispatchResult {
+			T::AdminOrigin::ensure_origin(origin)?;
+			ensure!(WhitelistedRequesters::<T>::contains_key(&who), Error::<T>::NotWhitelisted);
+			WhitelistedRequesters::<T>::remove(&who);
+			Self::deposit_event(Event::RequesterRemoved { who });
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// The bank sovereign account.
+		pub fn account_id() -> T::AccountId {
+			T::PalletId::get().into_account_truncating()
+		}
+
+		/// Free balance held by the bank.
+		pub fn balance() -> BalanceOf<T> {
+			T::Currency::free_balance(&Self::account_id())
+		}
+
+		/// Internal payment API — deliberately NOT an extrinsic.
+		///
+		/// Releases up to `amount` from the bank to `dest` on behalf of a
+		/// whitelisted `requester` (typically another pallet's sovereign
+		/// account). Never overdraws: pays `min(amount, free - ED)` and returns
+		/// the amount actually paid so the caller can account for the shortfall.
+		pub fn request_payment(
+			requester: &T::AccountId,
+			dest: &T::AccountId,
+			amount: BalanceOf<T>,
+		) -> Result<BalanceOf<T>, DispatchError> {
+			ensure!(
+				WhitelistedRequesters::<T>::contains_key(requester),
+				Error::<T>::RequesterNotWhitelisted
+			);
+			if amount.is_zero() {
+				return Ok(Zero::zero());
+			}
+			let bank = Self::account_id();
+			let available =
+				T::Currency::free_balance(&bank).saturating_sub(T::Currency::minimum_balance());
+			let paid = amount.min(available);
+			if !paid.is_zero() {
+				T::Currency::transfer(&bank, dest, paid, ExistenceRequirement::KeepAlive)?;
+				TotalPaidOut::<T>::mutate(|t| *t = t.saturating_add(paid));
+				TotalPaidByRequester::<T>::mutate(requester, |t| *t = t.saturating_add(paid));
+			}
+			Self::deposit_event(Event::PaymentReleased {
+				requester: requester.clone(),
+				dest: dest.clone(),
+				requested: amount,
+				paid,
+			});
+			Ok(paid)
+		}
+	}
+}

--- a/pallets/bank/src/mock.rs
+++ b/pallets/bank/src/mock.rs
@@ -1,0 +1,85 @@
+use crate as pallet_bank;
+use frame_support::{derive_impl, parameter_types, PalletId};
+use sp_keyring::AccountKeyring;
+use sp_runtime::{
+	traits::{IdentifyAccount, IdentityLookup, Verify},
+	BuildStorage,
+};
+
+pub type Signature = sp_runtime::MultiSignature;
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+pub type Balance = u128;
+
+pub const INITIAL_BALANCE: Balance = 10_000_000_000_000;
+pub const EXISTENTIAL_DEPOSIT: Balance = 1;
+
+frame_support::construct_runtime!(
+	pub enum Test
+	{
+		System: frame_system,
+		Balances: pallet_balances,
+		Bank: pallet_bank,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = frame_system::mocking::MockBlock<Test>;
+	type AccountId = AccountId;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type Lookup = IdentityLookup<Self::AccountId>;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type AccountStore = System;
+	type ExistentialDeposit = ExistentialDeposit;
+}
+
+parameter_types! {
+	pub const BankPalletId: PalletId = PalletId(*b"hip/bank");
+}
+
+impl pallet_bank::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type PalletId = BankPalletId;
+	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
+	type WeightInfo = ();
+}
+
+pub fn alice() -> AccountId {
+	AccountKeyring::Alice.to_account_id()
+}
+
+pub fn bob() -> AccountId {
+	AccountKeyring::Bob.to_account_id()
+}
+
+pub fn charlie() -> AccountId {
+	AccountKeyring::Charlie.to_account_id()
+}
+
+pub fn bank_account() -> AccountId {
+	pallet_bank::Pallet::<Test>::account_id()
+}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	pallet_balances::GenesisConfig::<Test> {
+		balances: vec![(alice(), INITIAL_BALANCE), (bob(), INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+	});
+	ext
+}

--- a/pallets/bank/src/tests.rs
+++ b/pallets/bank/src/tests.rs
@@ -1,0 +1,151 @@
+use crate::{
+	mock::*, DepositType, Error, Event, TotalDeposited, TotalPaidByRequester, TotalPaidOut,
+};
+use frame_support::{assert_noop, assert_ok};
+
+#[test]
+fn deposit_works() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Bank::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::StorageRevenue
+		));
+		assert_eq!(Balances::free_balance(bank_account()), 1_000);
+		assert_eq!(Balances::free_balance(alice()), INITIAL_BALANCE - 1_000);
+		assert_eq!(TotalDeposited::<Test>::get(DepositType::StorageRevenue), 1_000);
+		System::assert_last_event(
+			Event::Deposited {
+				who: alice(),
+				amount: 1_000,
+				deposit_type: DepositType::StorageRevenue,
+			}
+			.into(),
+		);
+
+		// A second deposit with a different type is accounted separately.
+		assert_ok!(Bank::deposit(RuntimeOrigin::signed(bob()), 500, DepositType::Grant));
+		assert_eq!(Balances::free_balance(bank_account()), 1_500);
+		assert_eq!(TotalDeposited::<Test>::get(DepositType::Grant), 500);
+		assert_eq!(TotalDeposited::<Test>::get(DepositType::StorageRevenue), 1_000);
+	});
+}
+
+#[test]
+fn deposit_zero_fails() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Bank::deposit(RuntimeOrigin::signed(alice()), 0, DepositType::Other),
+			Error::<Test>::ZeroAmount
+		);
+	});
+}
+
+#[test]
+fn whitelist_management_works() {
+	new_test_ext().execute_with(|| {
+		// Only the admin origin can manage the whitelist.
+		assert_noop!(
+			Bank::add_requester(RuntimeOrigin::signed(alice()), charlie()),
+			sp_runtime::DispatchError::BadOrigin
+		);
+
+		assert_ok!(Bank::add_requester(RuntimeOrigin::root(), charlie()));
+		System::assert_last_event(Event::RequesterAdded { who: charlie() }.into());
+		assert_noop!(
+			Bank::add_requester(RuntimeOrigin::root(), charlie()),
+			Error::<Test>::AlreadyWhitelisted
+		);
+
+		assert_noop!(
+			Bank::remove_requester(RuntimeOrigin::signed(alice()), charlie()),
+			sp_runtime::DispatchError::BadOrigin
+		);
+		assert_ok!(Bank::remove_requester(RuntimeOrigin::root(), charlie()));
+		System::assert_last_event(Event::RequesterRemoved { who: charlie() }.into());
+		assert_noop!(
+			Bank::remove_requester(RuntimeOrigin::root(), charlie()),
+			Error::<Test>::NotWhitelisted
+		);
+	});
+}
+
+#[test]
+fn request_payment_requires_whitelist() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Bank::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::StorageRevenue
+		));
+		assert_noop!(
+			Bank::request_payment(&charlie(), &bob(), 100),
+			Error::<Test>::RequesterNotWhitelisted
+		);
+	});
+}
+
+#[test]
+fn request_payment_pays_in_full_when_funded() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Bank::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::StorageRevenue
+		));
+		assert_ok!(Bank::add_requester(RuntimeOrigin::root(), charlie()));
+
+		let bob_before = Balances::free_balance(bob());
+		let paid = Bank::request_payment(&charlie(), &bob(), 400).unwrap();
+		assert_eq!(paid, 400);
+		assert_eq!(Balances::free_balance(bob()), bob_before + 400);
+		assert_eq!(Balances::free_balance(bank_account()), 600);
+		assert_eq!(TotalPaidOut::<Test>::get(), 400);
+		assert_eq!(TotalPaidByRequester::<Test>::get(charlie()), 400);
+		System::assert_last_event(
+			Event::PaymentReleased { requester: charlie(), dest: bob(), requested: 400, paid: 400 }
+				.into(),
+		);
+	});
+}
+
+#[test]
+fn request_payment_is_capped_at_available_balance() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Bank::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::StorageRevenue
+		));
+		assert_ok!(Bank::add_requester(RuntimeOrigin::root(), charlie()));
+
+		// Asks for more than the bank holds: pays balance minus ED, never fails.
+		let paid = Bank::request_payment(&charlie(), &bob(), 5_000).unwrap();
+		assert_eq!(paid, 1_000 - EXISTENTIAL_DEPOSIT);
+		assert_eq!(Balances::free_balance(bank_account()), EXISTENTIAL_DEPOSIT);
+		assert_eq!(TotalPaidOut::<Test>::get(), 1_000 - EXISTENTIAL_DEPOSIT);
+		System::assert_last_event(
+			Event::PaymentReleased {
+				requester: charlie(),
+				dest: bob(),
+				requested: 5_000,
+				paid: 1_000 - EXISTENTIAL_DEPOSIT,
+			}
+			.into(),
+		);
+
+		// Bank is now empty (only ED left): next request pays zero.
+		let paid = Bank::request_payment(&charlie(), &bob(), 100).unwrap();
+		assert_eq!(paid, 0);
+	});
+}
+
+#[test]
+fn request_payment_zero_is_noop() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Bank::add_requester(RuntimeOrigin::root(), charlie()));
+		let paid = Bank::request_payment(&charlie(), &bob(), 0).unwrap();
+		assert_eq!(paid, 0);
+		assert_eq!(TotalPaidOut::<Test>::get(), 0);
+	});
+}

--- a/pallets/bank/src/tests.rs
+++ b/pallets/bank/src/tests.rs
@@ -9,16 +9,16 @@ fn deposit_works() {
 		assert_ok!(Bank::deposit(
 			RuntimeOrigin::signed(alice()),
 			1_000,
-			DepositType::StorageRevenue
+			DepositType::MarketplaceRevenue
 		));
 		assert_eq!(Balances::free_balance(bank_account()), 1_000);
 		assert_eq!(Balances::free_balance(alice()), INITIAL_BALANCE - 1_000);
-		assert_eq!(TotalDeposited::<Test>::get(DepositType::StorageRevenue), 1_000);
+		assert_eq!(TotalDeposited::<Test>::get(DepositType::MarketplaceRevenue), 1_000);
 		System::assert_last_event(
 			Event::Deposited {
 				who: alice(),
 				amount: 1_000,
-				deposit_type: DepositType::StorageRevenue,
+				deposit_type: DepositType::MarketplaceRevenue,
 			}
 			.into(),
 		);
@@ -27,7 +27,7 @@ fn deposit_works() {
 		assert_ok!(Bank::deposit(RuntimeOrigin::signed(bob()), 500, DepositType::Grant));
 		assert_eq!(Balances::free_balance(bank_account()), 1_500);
 		assert_eq!(TotalDeposited::<Test>::get(DepositType::Grant), 500);
-		assert_eq!(TotalDeposited::<Test>::get(DepositType::StorageRevenue), 1_000);
+		assert_eq!(TotalDeposited::<Test>::get(DepositType::MarketplaceRevenue), 1_000);
 	});
 }
 
@@ -76,7 +76,7 @@ fn request_payment_requires_whitelist() {
 		assert_ok!(Bank::deposit(
 			RuntimeOrigin::signed(alice()),
 			1_000,
-			DepositType::StorageRevenue
+			DepositType::MarketplaceRevenue
 		));
 		assert_noop!(
 			Bank::request_payment(&charlie(), &bob(), 100),
@@ -91,7 +91,7 @@ fn request_payment_pays_in_full_when_funded() {
 		assert_ok!(Bank::deposit(
 			RuntimeOrigin::signed(alice()),
 			1_000,
-			DepositType::StorageRevenue
+			DepositType::MarketplaceRevenue
 		));
 		assert_ok!(Bank::add_requester(RuntimeOrigin::root(), charlie()));
 
@@ -115,7 +115,7 @@ fn request_payment_is_capped_at_available_balance() {
 		assert_ok!(Bank::deposit(
 			RuntimeOrigin::signed(alice()),
 			1_000,
-			DepositType::StorageRevenue
+			DepositType::MarketplaceRevenue
 		));
 		assert_ok!(Bank::add_requester(RuntimeOrigin::root(), charlie()));
 

--- a/pallets/bank/src/weights.rs
+++ b/pallets/bank/src/weights.rs
@@ -1,0 +1,62 @@
+//! Weights for pallet-bank
+//!
+//! Hand-written estimates following the repo convention (see
+//! `pallets/arion-pallet/src/weights.rs`) — run actual benchmarks in your
+//! runtime to refine.
+
+#![allow(unused_imports)]
+
+use frame_support::{
+	traits::Get,
+	weights::{constants::RocksDbWeight, Weight},
+};
+use sp_std::marker::PhantomData;
+
+pub trait WeightInfo {
+	fn deposit() -> Weight;
+	fn add_requester() -> Weight;
+	fn remove_requester() -> Weight;
+}
+
+/// Weights using runtime `DbWeight`.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	fn deposit() -> Weight {
+		// transfer (2 accounts) + TotalDeposited read/write
+		Weight::from_parts(50_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+
+	fn add_requester() -> Weight {
+		Weight::from_parts(15_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+
+	fn remove_requester() -> Weight {
+		Weight::from_parts(15_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+}
+
+impl WeightInfo for () {
+	fn deposit() -> Weight {
+		Weight::from_parts(50_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+
+	fn add_requester() -> Weight {
+		Weight::from_parts(15_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+
+	fn remove_requester() -> Weight {
+		Weight::from_parts(15_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+}

--- a/pallets/marketplace/Cargo.toml
+++ b/pallets/marketplace/Cargo.toml
@@ -37,6 +37,7 @@ pallet-credits = { default-features = false, workspace = true }
 num-traits = { version = "0.2.17", default-features = false }
 pallet-utils = { default-features = false, workspace = true }
 pallet-arion = { workspace = true, default-features = false }
+pallet-bank = { workspace = true, default-features = false }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407" }
@@ -65,7 +66,8 @@ std = [
     "pallet-utils/std",
     "pallet-rankings/std",
     "sp-io/std",
-    "pallet-arion/std"
+    "pallet-arion/std",
+    "pallet-bank/std",
 ]
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -148,6 +148,7 @@ pub mod pallet {
                     pallet_registration::Config + 
                     pallet_credits::Config + 
                     pallet_arion::Config +
+                    pallet_bank::Config +
                     pallet_balances::Config + 
                     pallet_calendar::Config +
                     // pallet_notifications::Config +
@@ -2041,6 +2042,31 @@ pub mod pallet {
             
             AlphaBalances::<T>::mutate(&sender, |alpha| *alpha = alpha.saturating_add(alpha_amount));
             CreditsPallet::<T>::do_mint(sender.clone(), credit_amount, code)?;
+
+            // Route the alpha backing of this deposit to the bank (miner
+            // payment funds). Sourced from the marketplace sudo account; never
+            // blocks the deposit itself if the transfer cannot be made.
+            if alpha_amount > 0 {
+                if let Some(sudo_account) = Self::sudo_key() {
+                    let backing: pallet_bank::BalanceOf<T> = alpha_amount.saturated_into();
+                    if let Err(e) = pallet_bank::Pallet::<T>::deposit_from(
+                        &sudo_account,
+                        backing,
+                        pallet_bank::DepositType::MarketplaceRevenue,
+                    ) {
+                        log::warn!(
+                            target: "runtime::marketplace",
+                            "deposit: routing alpha backing to bank failed: {:?}",
+                            e
+                        );
+                    }
+                } else {
+                    log::warn!(
+                        target: "runtime::marketplace",
+                        "deposit: no sudo key set, alpha backing not routed to bank"
+                    );
+                }
+            }
 
             Self::deposit_event(Event::BatchDeposited { owner: sender, batch_id });
 

--- a/runtime/mainnet/Cargo.toml
+++ b/runtime/mainnet/Cargo.toml
@@ -96,6 +96,7 @@ hippius-crypto-primitives = { workspace = true }
 
 #ipfs-pallet = { workspace = true }
 pallet-alpha-bridge = { workspace = true }
+pallet-bank = { workspace = true }
 pallet-utils = { workspace = true }
 pallet-registration = { workspace = true }
 pallet-arion = { workspace = true }
@@ -281,6 +282,7 @@ std = [
     "pallet-calendar/std",
     #"ipfs-pallet/std",
     "pallet-alpha-bridge/std",
+    "pallet-bank/std",
 	"pallet-registration/std",
     "pallet-execution-unit/std",
     "pallet-metagraph/std",

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -116,6 +116,24 @@ impl frame_support::traits::SortedMembers<AccountId> for ArionAdminMembers {
 	}
 }
 
+/// Adapter: arion pulls miner-payment funds from the bank pallet.
+/// The arion escrow account must be whitelisted via `bank.add_requester`.
+pub struct ArionPayoutSource;
+impl pallet_arion::PayoutSource<AccountId, Balance> for ArionPayoutSource {
+	fn request_payment(requester: &AccountId, dest: &AccountId, amount: Balance) -> Balance {
+		pallet_bank::Pallet::<Runtime>::request_payment(requester, dest, amount).unwrap_or(0)
+	}
+}
+
+/// Adapter: token price in USD (fixed-point 18 decimals) from the credits
+/// pallet alpha price feed.
+pub struct AlphaTokenPriceUsd;
+impl frame_support::traits::Get<u128> for AlphaTokenPriceUsd {
+	fn get() -> u128 {
+		pallet_credits::Pallet::<Runtime>::alpha_price()
+	}
+}
+
 // Implement Arion pallet configuration
 impl pallet_arion::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
@@ -167,6 +185,25 @@ impl pallet_arion::Config for Runtime {
 	type IntegrityFailPenalty = IntegrityFailPenalty;
 	type MinerStatsPruneInterval = ArionMinerStatsPruneInterval;
 	type MinerStatsPruneMaxScanPerBlock = ArionMinerStatsPruneMaxScanPerBlock;
+	type PalletId = ArionPalletId;
+	type PayoutSource = ArionPayoutSource;
+	type Staking = Staking;
+	type TokenPriceUsd = AlphaTokenPriceUsd;
+	type SettlementInterval = ArionSettlementInterval;
+}
+
+parameter_types! {
+	pub const BankPalletId: PalletId = PalletId(*b"hip/bank");
+	/// Miner payment settlement interval (~24h at 6s/block). `0` = disabled.
+	pub const ArionSettlementInterval: BlockNumber = 14_400;
+}
+
+impl pallet_bank::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type PalletId = BankPalletId;
+	type AdminOrigin = frame_system::EnsureSignedBy<ArionAdminMembers, AccountId>;
+	type WeightInfo = pallet_bank::weights::SubstrateWeight<Runtime>;
 }
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -255,7 +292,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 9194,
+	spec_version: 9195,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -1970,6 +2007,7 @@ construct_runtime!(
 		// IpfsPallet: ipfs_pallet = 75,
 		Arion: pallet_arion = 76,
 		PalletCalendar: pallet_calendar = 78,
+		Bank: pallet_bank = 80,
 	}
 );
 

--- a/runtime/mainnet/tests/miner_payments.rs
+++ b/runtime/mainnet/tests/miner_payments.rs
@@ -1,0 +1,305 @@
+//! End-to-end tests for the Arion miner payment flow, run against the real
+//! runtime: stats accrual → settlement → bank withdrawal → transfer → staking
+//! bond, plus the marketplace deposit → bank revenue routing.
+
+use frame_support::traits::{Currency, Hooks};
+use hippius_mainnet_runtime::{
+	AccountId, Arion, Balances, Bank, BlockNumber, Credits, Marketplace, Runtime, RuntimeEvent,
+	RuntimeOrigin, System,
+};
+use pallet_arion::{
+	ChildMinerUid, ChildRegistration, ChildRegistrations, ChildStatus, FamilyArrears,
+	MinerAccruals, MinerStats, MinerStatsUpdate, SettlementSkipReason,
+};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{AccountId32, BuildStorage};
+
+const UNIT: u128 = 1_000_000_000_000_000_000; // 18 decimals
+const GIB: u128 = 1 << 30;
+/// Must match `ArionSettlementInterval` in the runtime.
+const SETTLEMENT_BLOCK: BlockNumber = 14_400;
+
+/// The hardcoded `ArionAdminMembers` account (all arion/bank admin origins).
+fn admin() -> AccountId {
+	AccountId32::from_ss58check("5CVXqxb7mhFTtZVw5BJ8M2ujND9PFymSDxF8bkod6Sm4XJTW").unwrap()
+}
+
+fn account(seed: u8) -> AccountId {
+	AccountId32::new([seed; 32])
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
+/// Register an active child miner directly in storage (bypasses the
+/// signature/proxy/deposit machinery of `register_child`, which is not what
+/// these tests exercise).
+fn register_miner(family: &AccountId, child: &AccountId, uid: u32) {
+	ChildRegistrations::<Runtime>::insert(
+		child,
+		ChildRegistration {
+			family: family.clone(),
+			node_id: [uid as u8; 32],
+			status: ChildStatus::Active,
+			deposit: 0u128,
+			unbonding_end: 0u32.into(),
+		},
+	);
+	ChildMinerUid::<Runtime>::insert(child, uid);
+}
+
+/// Submit miner stats for `uid` at the current block (bucket = block number).
+fn submit_stats(uid: u32, bytes: u128) {
+	let bucket: u32 = System::block_number().try_into().unwrap_or(u32::MAX);
+	let updates = vec![MinerStatsUpdate {
+		uid,
+		stats: MinerStats { shard_data_bytes: bytes, ..Default::default() },
+	}];
+	Arion::submit_miner_stats(
+		RuntimeOrigin::signed(admin()),
+		bucket,
+		updates.try_into().expect("bounded"),
+		None,
+	)
+	.expect("stats submission");
+}
+
+/// Enable payments: price + token price feed + funded, whitelisted bank.
+fn enable_payments(price_usd_per_gb_block: u128, alpha_price: u128, bank_funds: u128) {
+	Arion::set_miner_price(RuntimeOrigin::signed(admin()), price_usd_per_gb_block)
+		.expect("set price");
+	pallet_credits::AlphaPrice::<Runtime>::put(alpha_price);
+	let _ = Balances::deposit_creating(&Bank::account_id(), bank_funds);
+	Bank::add_requester(RuntimeOrigin::signed(admin()), Arion::account_id())
+		.expect("whitelist arion escrow");
+}
+
+fn settle_at(n: BlockNumber) {
+	System::set_block_number(n);
+	Arion::on_initialize(n);
+}
+
+fn staking_ledger_active(who: &AccountId) -> u128 {
+	pallet_staking::Pallet::<Runtime>::ledger(sp_staking::StakingAccount::Stash(who.clone()))
+		.expect("ledger exists")
+		.active
+}
+
+#[test]
+fn accrual_integrates_bytes_over_blocks() {
+	new_test_ext().execute_with(|| {
+		let (family, child) = (account(1), account(2));
+		register_miner(&family, &child, 7);
+
+		// First submission creates the accrual entry (nothing accrued yet).
+		submit_stats(7, 100 * GIB);
+		let acc = MinerAccruals::<Runtime>::get(7).expect("entry created");
+		assert_eq!(acc.byte_blocks, 0);
+
+		// Ten blocks later: the *previous* value is integrated over 10 blocks.
+		System::set_block_number(11);
+		submit_stats(7, 42);
+		let acc = MinerAccruals::<Runtime>::get(7).expect("entry exists");
+		assert_eq!(acc.byte_blocks, 100 * GIB * 10);
+	});
+}
+
+#[test]
+fn settlement_pays_family_and_bonds_stake() {
+	new_test_ext().execute_with(|| {
+		let (family, child) = (account(1), account(2));
+		register_miner(&family, &child, 7);
+		submit_stats(7, 100 * GIB); // stored from block 1 onwards
+
+		let price = 10_000_000_000_u128; // $1e-8 per GiB per block
+		let alpha_price = UNIT / 20; // token at $0.05
+		enable_payments(price, alpha_price, 10 * UNIT);
+
+		settle_at(SETTLEMENT_BLOCK);
+
+		// Settlement accrues 100 GiB from block 1 to SETTLEMENT_BLOCK.
+		let byte_blocks = 100 * GIB * (SETTLEMENT_BLOCK as u128 - 1);
+		let expected = pallet_arion::tokens_for_byte_blocks(byte_blocks, price, alpha_price);
+		assert!(expected > 0);
+
+		// Paid in full and locked as bonded stake on the family account.
+		assert_eq!(Balances::free_balance(&family), expected);
+		assert_eq!(staking_ledger_active(&family), expected);
+		assert_eq!(FamilyArrears::<Runtime>::get(&family), 0);
+		// Accrual was reset by the settlement.
+		assert_eq!(MinerAccruals::<Runtime>::get(7).expect("entry").byte_blocks, 0);
+		// Bank accounting.
+		assert_eq!(pallet_bank::TotalPaidOut::<Runtime>::get(), expected);
+		assert_eq!(
+			pallet_bank::TotalPaidByRequester::<Runtime>::get(Arion::account_id()),
+			expected
+		);
+
+		let family_paid_ok = System::events().iter().any(|r| {
+			matches!(
+				&r.event,
+				RuntimeEvent::Arion(pallet_arion::Event::FamilyPaid {
+					family: f,
+					tokens,
+					staked: true,
+				}) if *f == family && *tokens == expected
+			)
+		});
+		assert!(family_paid_ok, "FamilyPaid {{ staked: true }} event expected");
+	});
+}
+
+#[test]
+fn shortfall_pays_pro_rata_and_carries_arrears() {
+	new_test_ext().execute_with(|| {
+		let (family_a, child_a) = (account(1), account(2));
+		let (family_b, child_b) = (account(3), account(4));
+		register_miner(&family_a, &child_a, 1);
+		register_miner(&family_b, &child_b, 2);
+		submit_stats(1, 200 * GIB);
+		submit_stats(2, 100 * GIB);
+
+		let price = 10_000_000_000_u128;
+		let alpha_price = UNIT / 20;
+		let elapsed = SETTLEMENT_BLOCK as u128 - 1;
+		let due_a = pallet_arion::tokens_for_byte_blocks(200 * GIB * elapsed, price, alpha_price);
+		let due_b = pallet_arion::tokens_for_byte_blocks(100 * GIB * elapsed, price, alpha_price);
+		let total_due = due_a + due_b;
+
+		// Fund the bank with only half of what is owed (+ ED it always keeps).
+		let half = total_due / 2;
+		enable_payments(price, alpha_price, half + 500);
+
+		settle_at(SETTLEMENT_BLOCK);
+
+		let paid_a = due_a * half / total_due;
+		let paid_b = due_b * half / total_due;
+		assert_eq!(Balances::free_balance(&family_a), paid_a);
+		assert_eq!(Balances::free_balance(&family_b), paid_b);
+		assert_eq!(FamilyArrears::<Runtime>::get(&family_a), due_a - paid_a);
+		assert_eq!(FamilyArrears::<Runtime>::get(&family_b), due_b - paid_b);
+
+		// Stop further accrual (previous bytes still accrue for one block).
+		System::set_block_number(SETTLEMENT_BLOCK + 1);
+		submit_stats(1, 0);
+		submit_stats(2, 0);
+		let extra_a = pallet_arion::tokens_for_byte_blocks(200 * GIB, price, alpha_price);
+		let extra_b = pallet_arion::tokens_for_byte_blocks(100 * GIB, price, alpha_price);
+
+		// Refill the bank: next settlement clears arrears (+ the one-block tail).
+		let _ = Balances::deposit_creating(&Bank::account_id(), total_due);
+		settle_at(2 * SETTLEMENT_BLOCK);
+
+		assert_eq!(FamilyArrears::<Runtime>::get(&family_a), 0);
+		assert_eq!(FamilyArrears::<Runtime>::get(&family_b), 0);
+		assert_eq!(Balances::free_balance(&family_a), due_a + extra_a);
+		assert_eq!(Balances::free_balance(&family_b), due_b + extra_b);
+		assert_eq!(staking_ledger_active(&family_a), due_a + extra_a);
+	});
+}
+
+#[test]
+fn settlement_skips_when_price_or_feed_is_zero() {
+	new_test_ext().execute_with(|| {
+		let (family, child) = (account(1), account(2));
+		register_miner(&family, &child, 7);
+		submit_stats(7, GIB);
+
+		// Price unset (0): skip, accruals untouched.
+		settle_at(SETTLEMENT_BLOCK);
+		let skipped_price = System::events().iter().any(|r| {
+			matches!(
+				&r.event,
+				RuntimeEvent::Arion(pallet_arion::Event::MinerPaymentSkipped {
+					reason: SettlementSkipReason::PriceUnset,
+				})
+			)
+		});
+		assert!(skipped_price);
+
+		// Price set but token price feed at zero: skip as well.
+		Arion::set_miner_price(RuntimeOrigin::signed(admin()), 1).expect("set price");
+		pallet_credits::AlphaPrice::<Runtime>::put(0);
+		settle_at(2 * SETTLEMENT_BLOCK);
+		let skipped_feed = System::events().iter().any(|r| {
+			matches!(
+				&r.event,
+				RuntimeEvent::Arion(pallet_arion::Event::MinerPaymentSkipped {
+					reason: SettlementSkipReason::TokenPriceUnavailable,
+				})
+			)
+		});
+		assert!(skipped_feed);
+		assert_eq!(Balances::free_balance(&family), 0);
+	});
+}
+
+#[test]
+fn extreme_values_saturate_without_panicking() {
+	new_test_ext().execute_with(|| {
+		let (family, child) = (account(1), account(2));
+		register_miner(&family, &child, 7);
+		submit_stats(7, u128::MAX);
+
+		// Absurd price and cheap token: every intermediate would overflow u128.
+		enable_payments(u128::MAX, 1, UNIT);
+
+		// Must complete: saturating math end to end, payment capped by the bank.
+		settle_at(SETTLEMENT_BLOCK);
+
+		// Bank paid out everything it could (down to its ED)...
+		assert_eq!(Balances::free_balance(&Bank::account_id()), 500);
+		assert_eq!(Balances::free_balance(&family), UNIT - 500);
+		// ...and the un-payable remainder is carried as (saturated) arrears.
+		assert!(FamilyArrears::<Runtime>::get(&family) > 0);
+	});
+}
+
+#[test]
+fn marketplace_deposit_routes_alpha_backing_to_bank() {
+	new_test_ext().execute_with(|| {
+		let authority = account(10);
+		let sudo = account(11);
+		let user = account(12);
+		Credits::add_authority(RuntimeOrigin::root(), authority.clone()).expect("add authority");
+		pallet_marketplace::SudoKey::<Runtime>::put(Some(sudo.clone()));
+		let _ = Balances::deposit_creating(&sudo, 100 * UNIT);
+
+		Marketplace::deposit(
+			RuntimeOrigin::signed(authority.clone()),
+			user.clone(),
+			5 * UNIT, // credits minted to the user
+			3 * UNIT, // alpha backing routed to the bank
+			false,
+			None,
+		)
+		.expect("marketplace deposit");
+
+		assert_eq!(Balances::free_balance(&Bank::account_id()), 3 * UNIT);
+		assert_eq!(Balances::free_balance(&sudo), 97 * UNIT);
+		assert_eq!(
+			pallet_bank::TotalDeposited::<Runtime>::get(
+				pallet_bank::DepositType::MarketplaceRevenue
+			),
+			3 * UNIT
+		);
+
+		// Without a sudo key the deposit itself still succeeds — the routing
+		// is skipped, never blocking credit purchases.
+		pallet_marketplace::SudoKey::<Runtime>::put(None::<AccountId>);
+		Marketplace::deposit(
+			RuntimeOrigin::signed(authority),
+			account(13),
+			5 * UNIT,
+			3 * UNIT,
+			false,
+			None,
+		)
+		.expect("deposit without sudo");
+		assert_eq!(Balances::free_balance(&Bank::account_id()), 3 * UNIT);
+	});
+}


### PR DESCRIPTION
## What

Pays Arion storage miners for the storage they actually provide, at a real USD price, with payouts locked as bonded stake.

- **New `pallet-bank`** (`pallets/bank`, index 80): holds the payment funds.
  - `deposit(amount, deposit_type)` — anyone can fund it; deposits are tagged (`MarketplaceRevenue | Emission | Grant | Other`).
  - `request_payment(requester, dest, amount)` — **internal API only** (not an extrinsic), gated by an admin-managed requester whitelist. Never overdraws: pays `min(requested, free − ED)` and returns the amount actually paid.
- **`pallet-arion` payment accounting**:
  - **Byte-blocks accrual** — on every `submit_miner_stats`, the *previous* `shard_data_bytes` value is integrated over the elapsed blocks into `MinerAccruals` before being overwritten. Miners are paid for bytes × time, never for a snapshot.
  - **`set_miner_price(price)`** (admin) — USD per GiB of raw shard data per block, fixed-point 18 decimals. `0` = payments disabled → **rollout switch**.
  - **Settlement** every `SettlementInterval` blocks (~24h) in `on_initialize`: accrues all active children, aggregates per **family**, converts USD → tokens using the credits pallet `alpha_price` feed (deterministic `U256` integer math, no `f64`), pulls the total from the bank into the arion escrow account (`py/arion`), and pays each family.
  - **Solvency backstop** — if the bank can't cover the full amount, families are paid pro-rata and the shortfall is carried in `FamilyArrears` (settled first next round). A settlement never fails as a whole.
  - **Payout as stake** — each family payout is transferred then bonded via `sp_staking::StakingInterface` (`bond_extra`, or `bond` for first-time stashes). This also counts toward the miner min-stake threshold read by `pallet-registration`. On bond failure the amount stays as free balance (`FamilyPaid { staked: false }`).
- **Marketplace → bank revenue routing** — on `marketplace.deposit`, 100% of the alpha backing (`alpha_amount`) is transferred from the marketplace sudo account to the bank, tagged `MarketplaceRevenue`. Best-effort: a missing sudo key or failed transfer never blocks the credit purchase. The pot that pays miners is funded end to end by user deposits.
- Coupling for arion is via runtime-side adapters (`ArionPayoutSource`, `AlphaTokenPriceUsd`) — no new inter-pallet crate dependencies, same pattern as `FamilyRegistry`/`ProxyVerifier`. The marketplace uses its established tight-coupling style (`pallet_bank::Config` supertrait).

## Why byte-blocks / raw bytes / per-family

- Paying on the `MinerStatsByUid` snapshot would pay a miner that joined an hour before settlement the same as one that stored data all day. Integrating bytes over blocks is the correct unit (GiB-blocks ≈ GiB-days).
- Miners are paid on **raw** stored bytes (erasure-coding parity included, 3× logical): intentional incentive at the current price point.
- Aggregation per family (the on-chain payout account); intra-family split is the operator's concern.
- No quality multiplier in v1: bad miners lose shards via off-chain CRUSH/repair and therefore lose bytes; quality already gates emissions via `FamilyWeight`.

## Deliberately out of scope

- User/client **charging** (marketplace consume/subscriptions) is untouched — handled off-chain (business decision). Only the deposit-side revenue routing was added.
- A follow-up will have the marketplace pull staker rewards from the bank as a whitelisted requester (replacing the sudo-sourced 70/30 split) — out of scope here.
- This coexists with the execution-unit / Bittensor weight emissions; it does not replace them.
- Hand-rolled weights, consistent with the rest of the repo (no benchmark harness wired).

## Storage / migration

Only new storage items with defaults (`MinerPriceUsdPerGbBlock`, `MinerAccruals`, `FamilyArrears`, `LastSettlementBlock`, bank maps). `MinerStats` struct untouched → **no migration needed**. `spec_version` 9194 → 9195.

## Activation runbook (after upgrade)

1. `bank.add_requester(arion_escrow)` — arion escrow = `PalletId(*b"py/arion").into_account_truncating()`.
2. Fund: automatic from now on (every `marketplace.deposit` routes its alpha backing to the bank — requires the marketplace sudo account to be provisioned), plus manual `bank.deposit(amount, ...)` top-ups if needed.
3. Let accruals run with price at 0; sanity-check `MinerAccruals` against `total_shard_data_bytes × elapsed`.
4. `arion.set_miner_price(price_usd_per_gb_block)` (18 decimals) — payments go live at the next settlement tick.

Kill switch: `arion.set_miner_price(0)` (accruals keep accumulating, nothing is lost).

## Testing

- **End-to-end integration tests against the real runtime** (`runtime/mainnet/tests/miner_payments.rs`, `cargo test -p hippius-mainnet-runtime --test miner_payments`, 6/6 green — real `pallet_staking`, no mocks): accrual over blocks; settlement pays and **bonds** the family payout (staking ledger asserted); bank shortfall → pro-rata + arrears carried then cleared; clean skips on zero price/feed; `u128::MAX` inputs saturate without panicking; `marketplace.deposit` routes the alpha backing to the bank.
- `cargo test -p pallet-bank -p pallet-arion` — bank: deposit/whitelist/request_payment incl. shortfall + ED preservation; arion: pure payment-math unit tests (linearity, rounding, overflow saturation, zero price). All green.
- `cargo check -p pallet-arion -p pallet-bank -p hippius-mainnet-runtime` — clean.
- `cargo fmt` clean on both touched pallets.
- Note: no test/lint CI runs on feature branches in this repo (build.yml triggers on `main` only) — validation above is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
