### PR TITLE
fix(runtime): raise Max24HourMinerPayout to 3500 hAlpha

### DIFF
--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -254,7 +254,7 @@ parameter_types! {
 	/// Miner payment settlement interval (~24h at 6s/block). `0` = disabled.
 	pub const ArionSettlementInterval: BlockNumber = 14_400;
 	pub const BlocksPer24Hours: BlockNumber = 14_400; // ~24 hours at 6-second blocks
-	pub const Max24HourMinerPayout: Balance = 1_500_000_000_000_000_000_000; // 1500 alpha (18 decimals)
+	pub const Max24HourMinerPayout: Balance = 3_500_000_000_000_000_000_000; // 3500 alpha (18 decimals): miner-share inflow (2952/day) + self-healing headroom
 }
 
 impl pallet_hippocampus::Config for Runtime {
@@ -354,7 +354,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 9198,
+	spec_version: 9199,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`


### PR DESCRIPTION
## Why

The mining-reward wallet receives the SN75 **miner share**: 0.41 alpha/block = **2952 alpha/day**. The current payout cap of 1500/24h falls behind inflow by 1452/day, so the Hippocampus Emission compartment backlog grows without bound.

## What

- `Max24HourMinerPayout`: 1500 → **3500 hAlpha** (daily inflow + ~550/day of self-healing headroom so a pipeline outage catches up on its own instead of freezing the missed amount in the compartment)
- `spec_version`: 9198 → 9199

Sized against live SN75 emission parameters (tempo 360, alpha-out 1/block, owner cut 18%, miner share 41%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)