### PR TITLE
feat(arion): weight hygiene — prune stale entries + aggregate family scoring

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,44 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: pr-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y clang cmake pkg-config libssl-dev git protobuf-compiler
+
+      - name: Install Rust 1.85 and required components
+        run: |
+          rustup install 1.85.0
+          rustup default 1.85.0
+          rustup override set 1.85.0
+          rustup target add wasm32-unknown-unknown --toolchain 1.85.0
+          rustup component add rust-src --toolchain 1.85.0-x86_64-unknown-linux-gnu
+          rustc --version
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pr-tests
+
+      # All mainnet-runtime integration suites (runtime/mainnet/tests/*:
+      # miner payments, adversarial, referral, prune_stale_node_weights, ...).
+      # `--test '*'` deliberately skips the runtime lib unittests: the
+      # auto-generated construct_runtime integrity test fails on a
+      # pre-existing staking config issue (slash defer 10 >= bonding 8),
+      # unrelated to PRs under test.
+      - name: Run runtime integration tests
+        run: cargo test -p hippius-mainnet-runtime --test '*'

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -617,6 +617,11 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxNodeWeightPrunePerCall: Get<u32>;
 
+		/// Max `NodeWeightByChild` entries scanned per `prune_stale_node_weights` call.
+		/// Bounds the walk even when every scanned entry is live (nothing to prune).
+		#[pallet::constant]
+		type MaxNodeWeightScanPerCall: Get<u32>;
+
 		// --- Registration economics / safety controls ---
 
 		/// Max distinct families that can ever claim their first “free” child slot.
@@ -943,6 +948,11 @@ pub mod pallet {
 	/// Last `MinerStatsByUid` key processed by batched pruning (`None` = next pass from the start).
 	#[pallet::storage]
 	pub type MinerStatsPruneCursor<T> = StorageValue<_, u32, OptionQuery>;
+
+	/// Last `NodeWeightByChild` key scanned by `prune_stale_node_weights`
+	/// (`None` = next call restarts from the beginning of the map).
+	#[pallet::storage]
+	pub type NodeWeightPruneCursor<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
 	// -------------------------
 	// Miner payment state
@@ -3338,12 +3348,18 @@ pub mod pallet {
 		///
 		/// Restricted to `WeightAuthorityOrigin` (the whitelisted chain-submitter), same as
 		/// `submit_node_quality`: weight state is authority-owned, so its cleanup is too.
+		///
+		/// The walk over `NodeWeightByChild` is bounded by `max_scan` and resumable via
+		/// [`NodeWeightPruneCursor`], so a map full of live entries cannot make a single
+		/// call scan unboundedly: repeated calls page through the whole map and the
+		/// cursor resets once the end is reached.
 		#[pallet::call_index(39)]
-		#[pallet::weight((<T as pallet::Config>::WeightInfo::prune_stale_node_weights(*max_children), Pays::No))]
+		#[pallet::weight((<T as pallet::Config>::WeightInfo::prune_stale_node_weights(*max_scan), Pays::No))]
 		pub fn prune_stale_node_weights(
 			origin: OriginFor<T>,
 			min_stale_buckets: u32,
 			max_children: u32,
+			max_scan: u32,
 		) -> DispatchResult {
 			T::WeightAuthorityOrigin::ensure_origin(origin)?;
 
@@ -3352,17 +3368,35 @@ pub mod pallet {
 				max_children > 0 && max_children <= cap,
 				Error::<T>::InvalidNodeWeightPruneBatch
 			);
+			ensure!(
+				max_scan >= max_children && max_scan <= T::MaxNodeWeightScanPerCall::get(),
+				Error::<T>::InvalidNodeWeightPruneBatch
+			);
 			// Floor of 2 buckets: live children lag at most 1 bucket behind the submitter.
 			ensure!(min_stale_buckets >= 2, Error::<T>::InvalidNodeWeightPruneBatch);
 
 			let cur = CurrentWeightBucket::<T>::get();
 
+			// Resume the walk where the previous call stopped.
+			let iter = match NodeWeightPruneCursor::<T>::get() {
+				Some(last) => NodeWeightByChild::<T>::iter_from(
+					NodeWeightByChild::<T>::hashed_key_for(&last),
+				),
+				None => NodeWeightByChild::<T>::iter(),
+			};
+
 			// Collect first, then mutate: never remove from a map while iterating it.
 			let mut targets: Vec<T::AccountId> = Vec::new();
-			for (child, _weight) in NodeWeightByChild::<T>::iter() {
-				if targets.len() as u32 >= max_children {
+			let mut scanned: u32 = 0;
+			let mut last_scanned: Option<T::AccountId> = None;
+			let mut exhausted = true;
+			for (child, _weight) in iter {
+				if scanned >= max_scan || targets.len() as u32 >= max_children {
+					exhausted = false;
 					break;
 				}
+				scanned = scanned.saturating_add(1);
+				last_scanned = Some(child.clone());
 				// Missing last-bucket entry decodes as default 0 == infinitely stale.
 				let last = NodeWeightLastBucket::<T>::get(&child);
 				if cur.saturating_sub(last) <= min_stale_buckets {
@@ -3375,6 +3409,15 @@ pub mod pallet {
 				if !active {
 					targets.push(child);
 				}
+			}
+
+			// Cursor: park at the last scanned key, reset once the map end is reached
+			// (removed targets are gone, so parking on one of them is still a valid
+			// resume point — iter_from starts strictly after the given key).
+			if exhausted {
+				NodeWeightPruneCursor::<T>::kill();
+			} else if let Some(last) = last_scanned {
+				NodeWeightPruneCursor::<T>::put(last);
 			}
 
 			let mut families: Vec<T::AccountId> = Vec::new();

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -613,6 +613,10 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxAttestationBucketsPrunePerCall: Get<u32>;
 
+		/// Max child weight entries removed per `prune_stale_node_weights` call (bounds weight).
+		#[pallet::constant]
+		type MaxNodeWeightPrunePerCall: Get<u32>;
+
 		// --- Registration economics / safety controls ---
 
 		/// Max distinct families that can ever claim their first “free” child slot.
@@ -1286,6 +1290,11 @@ pub mod pallet {
 			pruned: u32,
 			next_epoch: u64,
 		},
+		/// Stale node weight/quality entries of non-active children were pruned.
+		StaleNodeWeightsPruned {
+			children_pruned: u32,
+			families_pruned: u32,
+		},
 		UserStatsUpdated {
 			user: T::AccountId,
 			size: u128,
@@ -1441,6 +1450,8 @@ pub mod pallet {
 		InvalidAttestationPruneBatch,
 		/// `free_child_slots_per_family` exceeds [`Config::MaxChildrenPerFamily`].
 		FreeChildSlotsPerFamilyTooLarge,
+		/// Batch/staleness parameters for `prune_stale_node_weights` are out of bounds.
+		InvalidNodeWeightPruneBatch,
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -3312,6 +3323,90 @@ pub mod pallet {
 			}
 
 			Self::deposit_event(Event::CrushEpochsPruned { start_epoch, pruned, next_epoch: e });
+			Ok(())
+		}
+
+		/// Remove stale per-child node weight/quality entries left behind by children that are
+		/// no longer `Active` (legacy deregistrations that predate automatic cleanup, expired
+		/// unbondings, forced removals). Also sweeps family weight entries of families with no
+		/// active children left.
+		///
+		/// A child entry is pruned only when BOTH hold:
+		/// - its `NodeWeightLastBucket` is older than `min_stale_buckets` (live children are
+		///   refreshed every bucket by the chain-submitter, so they are never eligible), and
+		/// - it has no `Active` registration in `ChildRegistrations`.
+		///
+		/// Restricted to `WeightAuthorityOrigin` (the whitelisted chain-submitter), same as
+		/// `submit_node_quality`: weight state is authority-owned, so its cleanup is too.
+		#[pallet::call_index(39)]
+		#[pallet::weight((<T as pallet::Config>::WeightInfo::prune_stale_node_weights(*max_children), Pays::No))]
+		pub fn prune_stale_node_weights(
+			origin: OriginFor<T>,
+			min_stale_buckets: u32,
+			max_children: u32,
+		) -> DispatchResult {
+			T::WeightAuthorityOrigin::ensure_origin(origin)?;
+
+			let cap = T::MaxNodeWeightPrunePerCall::get();
+			ensure!(
+				max_children > 0 && max_children <= cap,
+				Error::<T>::InvalidNodeWeightPruneBatch
+			);
+			// Floor of 2 buckets: live children lag at most 1 bucket behind the submitter.
+			ensure!(min_stale_buckets >= 2, Error::<T>::InvalidNodeWeightPruneBatch);
+
+			let cur = CurrentWeightBucket::<T>::get();
+
+			// Collect first, then mutate: never remove from a map while iterating it.
+			let mut targets: Vec<T::AccountId> = Vec::new();
+			for (child, _weight) in NodeWeightByChild::<T>::iter() {
+				if targets.len() as u32 >= max_children {
+					break;
+				}
+				// Missing last-bucket entry decodes as default 0 == infinitely stale.
+				let last = NodeWeightLastBucket::<T>::get(&child);
+				if cur.saturating_sub(last) <= min_stale_buckets {
+					continue;
+				}
+				let active = matches!(
+					ChildRegistrations::<T>::get(&child),
+					Some(reg) if reg.status == ChildStatus::Active
+				);
+				if !active {
+					targets.push(child);
+				}
+			}
+
+			let mut families: Vec<T::AccountId> = Vec::new();
+			for child in &targets {
+				if let Some(reg) = ChildRegistrations::<T>::get(child) {
+					if !families.contains(&reg.family) {
+						families.push(reg.family);
+					}
+				}
+				Self::remove_child_node_weight_entries(child);
+			}
+
+			// Family sweep: drop weight entries of families with no active children left.
+			// Deliberately does NOT touch `FamilyCount` / `FamilyUsedFreeSlot`: those are
+			// registration-lifecycle state owned by the deregistration paths.
+			let mut families_pruned: u32 = 0;
+			for family in &families {
+				if FamilyActiveChildren::<T>::get(family) == 0 {
+					FamilyFirstSeenBucket::<T>::remove(family);
+					FamilyWeightRaw::<T>::remove(family);
+					FamilyWeight::<T>::remove(family);
+					families_pruned = families_pruned.saturating_add(1);
+				}
+			}
+
+			if !targets.is_empty() || families_pruned > 0 {
+				Self::deposit_event(Event::StaleNodeWeightsPruned {
+					children_pruned: targets.len() as u32,
+					families_pruned,
+				});
+			}
+
 			Ok(())
 		}
 	}

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -622,6 +622,16 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxNodeWeightScanPerCall: Get<u32>;
 
+		/// Max families visited per `submit_node_quality` family-weight recompute page.
+		///
+		/// Bounds the recompute so its cost cannot outgrow the declared weight as the
+		/// family set grows. Coverage is not lost, only spread: [`FamilyRecomputeCursor`]
+		/// resumes the walk on the next call, so consecutive calls page through the whole
+		/// map. Tune against `MaxChildrenPerFamily` — declared weight scales with the
+		/// product, since a page may hit families that are all at the child cap.
+		#[pallet::constant]
+		type MaxFamilyRecomputePerCall: Get<u32>;
+
 		// --- Registration economics / safety controls ---
 
 		/// Max distinct families that can ever claim their first “free” child slot.
@@ -965,6 +975,11 @@ pub mod pallet {
 	/// (`None` = next call restarts from the beginning of the map).
 	#[pallet::storage]
 	pub type NodeWeightPruneCursor<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
+	/// Last `FamilyActiveChildren` key visited by the family-weight recompute page
+	/// (`None` = next call restarts from the beginning of the map).
+	#[pallet::storage]
+	pub type FamilyRecomputeCursor<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
 	// -------------------------
 	// Miner payment state
@@ -2249,13 +2264,24 @@ pub mod pallet {
 			let base = blend.saturating_mul(max_score) / den_fx;
 
 			// Uptime multiplier, then penalties (same constants as per-node scoring).
+			//
+			// Penalties are averaged over the contributing children, not summed. Summing
+			// breaks the fragmentation invariance this function exists for: the base score
+			// is logarithmic in AGGREGATE bytes, so it is unchanged by splitting data across
+			// more children, but a summed penalty scales linearly with child count. The same
+			// 4 TiB carrying one strike per node would cost 1x the penalty as a single child
+			// and 4x as four, making fragmentation anything but neutral. Averaging keeps
+			// "one strike per node" costing the same regardless of how the data is split,
+			// while a single bad node among many correctly dilutes.
 			let with_uptime = base.saturating_mul(uptime) / 1000u128;
-			let pen = (strikes_total as u128)
+			let pen_total = (strikes_total as u128)
 				.saturating_mul(T::StrikePenalty::get() as u128)
 				.saturating_add(
 					(integrity_total as u128)
 						.saturating_mul(T::IntegrityFailPenalty::get() as u128),
 				);
+			// `fresh_children` is non-zero: the early return above covers the zero case.
+			let pen = pen_total / fresh_children;
 			let final_score = with_uptime.saturating_sub(pen).min(max_score);
 			final_score as u16
 		}
@@ -2368,13 +2394,49 @@ pub mod pallet {
 				updates: updates.len() as u32,
 			});
 
-			// Recompute every family with active children so weights cannot be suppressed by
-			// omitting a family's children from this batch.
+			// Recompute families with active children in a bounded, resumable page.
+			//
+			// Weights still cannot be suppressed by omitting a family's children from this
+			// batch: which families a page covers is driven by the on-chain cursor, never by
+			// the batch contents, so a submitter has no way to steer the walk away from a
+			// family. Bounding the page is what keeps the work inside the declared weight —
+			// an unbounded walk costs `families x children x 3` reads while the weight is
+			// keyed only on `updates.len()`.
+			//
+			// The scan is metered, not just the recompute list: families sitting at zero
+			// active children are skipped but still cost a read, so counting only pushed
+			// families would leave the same unbounded walk in place.
+			let max_families = T::MaxFamilyRecomputePerCall::get().max(1);
+			let family_iter = match FamilyRecomputeCursor::<T>::get() {
+				Some(last) => FamilyActiveChildren::<T>::iter_from(
+					FamilyActiveChildren::<T>::hashed_key_for(&last),
+				),
+				None => FamilyActiveChildren::<T>::iter(),
+			};
+
 			let mut families_to_recompute: sp_std::vec::Vec<T::AccountId> = sp_std::vec::Vec::new();
-			for (family, n) in FamilyActiveChildren::<T>::iter() {
+			let mut scanned: u32 = 0;
+			let mut last_scanned: Option<T::AccountId> = None;
+			let mut exhausted = true;
+			for (family, n) in family_iter {
+				if scanned >= max_families {
+					exhausted = false;
+					break;
+				}
+				scanned = scanned.saturating_add(1);
+				last_scanned = Some(family.clone());
 				if n > 0 {
 					families_to_recompute.push(family);
 				}
+			}
+
+			// Park at the last scanned key; reset once the map end is reached so the next
+			// call starts a fresh pass. `iter_from` resumes strictly after the given key, so
+			// parking on a family that is later removed is still a valid resume point.
+			if exhausted {
+				FamilyRecomputeCursor::<T>::kill();
+			} else if let Some(last) = last_scanned {
+				FamilyRecomputeCursor::<T>::put(last);
 			}
 
 			let mut computed: u32 = 0;
@@ -2909,7 +2971,11 @@ pub mod pallet {
 		///
 		/// This is the **recommended** path (deterministic on-chain weight calculation).
 		#[pallet::call_index(20)]
-		#[pallet::weight((<T as pallet::Config>::WeightInfo::submit_node_quality(updates.len() as u32), Pays::No))]
+		#[pallet::weight((<T as pallet::Config>::WeightInfo::submit_node_quality(
+			updates.len() as u32,
+			T::MaxFamilyRecomputePerCall::get(),
+			T::MaxChildrenPerFamily::get(),
+		), Pays::No))]
 		pub fn submit_node_quality(
 			origin: OriginFor<T>,
 			bucket: u32,
@@ -3421,7 +3487,7 @@ pub mod pallet {
 		/// call scan unboundedly: repeated calls page through the whole map and the
 		/// cursor resets once the end is reached.
 		#[pallet::call_index(39)]
-		#[pallet::weight((<T as pallet::Config>::WeightInfo::prune_stale_node_weights(*max_scan), Pays::No))]
+		#[pallet::weight((<T as pallet::Config>::WeightInfo::prune_stale_node_weights(*max_scan, *max_children), Pays::No))]
 		pub fn prune_stale_node_weights(
 			origin: OriginFor<T>,
 			min_stale_buckets: u32,

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -666,13 +666,25 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxFamilyWeight: Get<u16>;
 
-		/// How many top node weights to count per family (anti “just add infinite children”).
+		/// Byte total at (or below) which a family's aggregate score is 0.
+		/// Lower bound of the useful scoring range (e.g. 100 GiB).
 		#[pallet::constant]
-		type FamilyTopN: Get<u32>;
+		type FamilyScoreFloorBytes: Get<u128>;
 
-		/// Decay factor per rank (permille). Example: 800 → each next node contributes 0.8x the previous.
+		/// Byte total at (or above) which a family's aggregate score reaches [`Config::MaxFamilyScore`].
+		/// Upper bound of the useful scoring range (e.g. 1 PiB).
 		#[pallet::constant]
-		type FamilyRankDecayPermille: Get<u32>;
+		type FamilyScoreCeilBytes: Get<u128>;
+
+		/// Maximum achievable family score from the aggregate formula.
+		/// MUST be < `MaxFamilyWeight` so families can never sit at the storage-type ceiling.
+		#[pallet::constant]
+		type MaxFamilyScore: Get<u16>;
+
+		/// A child whose `NodeWeightLastBucket` is older than this many buckets contributes
+		/// nothing to its family's aggregate (live children are refreshed every bucket).
+		#[pallet::constant]
+		type StaleChildBuckets: Get<u32>;
 
 		/// EMA alpha (permille) for smoothing family weight over time.
 		/// Example: 300 → 30% new, 70% previous.
@@ -2130,46 +2142,101 @@ pub mod pallet {
 			v.min(u16::MAX as u128) as u16
 		}
 
-		fn compute_family_weight_from_nodes(family: &T::AccountId) -> u16 {
-			let max_node = T::MaxNodeWeight::get();
-			let max_family = T::MaxFamilyWeight::get();
-			let top_n = T::FamilyTopN::get().max(1) as usize;
-			let decay = T::FamilyRankDecayPermille::get().min(1000);
-
+		/// Compute a family's weight by scoring its AGGREGATE contribution, not by summing
+		/// per-node scores. This makes the result invariant to how an operator splits the
+		/// same data across children: 1 node with 200 TB scores exactly like 200 nodes with
+		/// 1 TB each. Piling on empty/dust children adds nothing (zero bytes → zero effect).
+		///
+		/// Only `Active` children whose quality was refreshed within
+		/// [`Config::StaleChildBuckets`] contribute; dark children decay out naturally.
+		///
+		/// The log2 blend is normalized over the useful range
+		/// [`Config::FamilyScoreFloorBytes`, `Config::FamilyScoreCeilBytes`] and scaled to
+		/// [`Config::MaxFamilyScore`] (< `MaxFamilyWeight`), so the storage-type ceiling is
+		/// unreachable: rankings never collapse into a saturated plateau.
+		fn compute_family_weight_from_nodes(family: &T::AccountId, current_bucket: u32) -> u16 {
 			let children = FamilyChildren::<T>::get(family);
 			if children.is_empty() {
 				return 0;
 			}
 
-			// Collect node weights for this family.
-			let mut ws: sp_std::vec::Vec<u16> = sp_std::vec::Vec::with_capacity(children.len());
+			// Aggregate raw quality over fresh, Active children. u128 saturating adds:
+			// even MaxChildrenPerFamily children reporting u128::MAX cannot overflow/panic.
+			let stale = T::StaleChildBuckets::get();
+			let mut st_total: u128 = 0;
+			let mut bw_total: u128 = 0;
+			// Weighted uptime numerator: sum(uptime_i * bytes_i). Max per term is
+			// 1000 * u128::MAX which saturates safely; realistic values are far below.
+			let mut up_num: u128 = 0;
+			let mut up_plain_sum: u128 = 0;
+			let mut fresh_children: u128 = 0;
+			let mut strikes_total: u32 = 0;
+			let mut integrity_total: u32 = 0;
 			for c in children.iter() {
-				let w = NodeWeightByChild::<T>::get(c).min(max_node);
-				if w > 0 {
-					ws.push(w);
+				let active = matches!(
+					ChildRegistrations::<T>::get(c),
+					Some(reg) if reg.status == ChildStatus::Active
+				);
+				if !active {
+					continue;
 				}
+				let last = NodeWeightLastBucket::<T>::get(c);
+				if current_bucket.saturating_sub(last) > stale {
+					continue;
+				}
+				let Some(q) = NodeQualityByChild::<T>::get(c) else { continue };
+				let up = q.uptime_permille.min(1000) as u128;
+				st_total = st_total.saturating_add(q.shard_data_bytes);
+				bw_total = bw_total.saturating_add(q.bandwidth_bytes);
+				up_num = up_num.saturating_add(up.saturating_mul(q.shard_data_bytes));
+				up_plain_sum = up_plain_sum.saturating_add(up);
+				fresh_children = fresh_children.saturating_add(1);
+				strikes_total = strikes_total.saturating_add(q.strikes);
+				integrity_total = integrity_total.saturating_add(q.integrity_fails);
 			}
-			if ws.is_empty() {
+			if fresh_children == 0 {
 				return 0;
 			}
-			ws.sort_unstable_by(|a, b| b.cmp(a)); // desc
 
-			// Top-N with rank decay: w0 + w1*decay + w2*decay^2 ...
-			let mut factor_permille: u128 = 1000;
-			let mut sum: u128 = 0;
-			for (i, w) in ws.iter().take(top_n).enumerate() {
-				if i == 0 {
-					// factor=1000 for first term
-				} else {
-					factor_permille = factor_permille.saturating_mul(decay as u128) / 1000u128;
-				}
-				let term = (*w as u128).saturating_mul(factor_permille) / 1000u128;
-				sum = sum.saturating_add(term);
-				if sum >= max_family as u128 {
-					return max_family;
-				}
-			}
-			sum.min(max_family as u128) as u16
+			// Uptime of the aggregate: byte-weighted when bytes exist, plain mean otherwise.
+			let uptime = if st_total > 0 {
+				(up_num / st_total).min(1000)
+			} else {
+				(up_plain_sum / fresh_children).min(1000)
+			};
+
+			// Normalize log2 of the aggregates over [floor, ceil]. All fixed-point 8.8
+			// (log2 * 256), so every value fits in u32 and products stay tiny for u128.
+			let lo_fx = Self::log2_fixed_u128(T::FamilyScoreFloorBytes::get().max(1)) as u128;
+			let hi_fx = Self::log2_fixed_u128(T::FamilyScoreCeilBytes::get().max(2)) as u128;
+			let den_fx = hi_fx.saturating_sub(lo_fx).max(1);
+			let component = |bytes: u128| -> u128 {
+				let v = Self::log2_fixed_u128(bytes.saturating_add(1)) as u128;
+				v.saturating_sub(lo_fx).min(den_fx)
+			};
+			let bw_w = T::NodeBandwidthWeightPermille::get().min(1000) as u128;
+			let st_w = T::NodeStorageWeightPermille::get().min(1000) as u128;
+			let denom_w = (bw_w + st_w).max(1);
+			// Max blend = den_fx * 1000; den_fx <= 127*256+255 (~32.7k) → max ~32.7M, fits u128.
+			let blend = component(bw_total)
+				.saturating_mul(bw_w)
+				.saturating_add(component(st_total).saturating_mul(st_w))
+				/ denom_w;
+
+			// Scale to MaxFamilyScore. Max product = 32.7k * 60_000 (~2e9) — fits u128.
+			let max_score = T::MaxFamilyScore::get().min(T::MaxFamilyWeight::get()) as u128;
+			let base = blend.saturating_mul(max_score) / den_fx;
+
+			// Uptime multiplier, then penalties (same constants as per-node scoring).
+			let with_uptime = base.saturating_mul(uptime) / 1000u128;
+			let pen = (strikes_total as u128)
+				.saturating_mul(T::StrikePenalty::get() as u128)
+				.saturating_add(
+					(integrity_total as u128)
+						.saturating_mul(T::IntegrityFailPenalty::get() as u128),
+				);
+			let final_score = with_uptime.saturating_sub(pen).min(max_score);
+			final_score as u16
 		}
 
 		pub fn get_total_family_weight() -> u128 {
@@ -2291,7 +2358,7 @@ pub mod pallet {
 
 			let mut computed: u32 = 0;
 			for family in families_to_recompute.iter() {
-				let raw = Self::compute_family_weight_from_nodes(family);
+				let raw = Self::compute_family_weight_from_nodes(family, bucket);
 
 				// Newcomer floor, only if raw > 0 and within grace
 				let raw = if raw > 0 {

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -2417,18 +2417,19 @@ pub mod pallet {
 			let mut families_to_recompute: sp_std::vec::Vec<T::AccountId> = sp_std::vec::Vec::new();
 			let mut scanned: u32 = 0;
 			let mut last_scanned: Option<T::AccountId> = None;
-			let mut exhausted = true;
-			for (family, n) in family_iter {
-				if scanned >= max_families {
-					exhausted = false;
-					break;
-				}
+			// `take` bounds the walk without fetching a further entry to discard, so the
+			// page costs exactly `max_families` reads rather than one more.
+			for (family, n) in family_iter.take(max_families as usize) {
 				scanned = scanned.saturating_add(1);
 				last_scanned = Some(family.clone());
 				if n > 0 {
 					families_to_recompute.push(family);
 				}
 			}
+			// A short page means the map ended inside it. Ending exactly on the boundary
+			// parks the cursor instead; the next call then reads nothing and resets, which
+			// costs one extra call and never skips a family.
+			let exhausted = scanned < max_families;
 
 			// Park at the last scanned key; reset once the map end is reached so the next
 			// call starts a fresh pass. `iter_from` resumes strictly after the given key, so
@@ -2973,7 +2974,7 @@ pub mod pallet {
 		#[pallet::call_index(20)]
 		#[pallet::weight((<T as pallet::Config>::WeightInfo::submit_node_quality(
 			updates.len() as u32,
-			T::MaxFamilyRecomputePerCall::get(),
+			T::MaxFamilyRecomputePerCall::get().max(1),
 			T::MaxChildrenPerFamily::get(),
 		), Pays::No))]
 		pub fn submit_node_quality(

--- a/pallets/arion-pallet/src/weights.rs
+++ b/pallets/arion-pallet/src/weights.rs
@@ -46,6 +46,7 @@ pub trait WeightInfo {
     fn deregister_warden() -> Weight;
     fn prune_attestation_buckets(n: u32) -> Weight;
     fn prune_historical_crush_epochs(n: u32) -> Weight;
+    fn prune_stale_node_weights(n: u32) -> Weight;
     /// See [`UPDATE_USER_FILE_SIZE_READ_BUDGET`].
     fn update_user_file_size() -> Weight;
     /// `on_initialize` miner stats prune: bounded scan + protected-uid pass over registrations.
@@ -233,6 +234,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().writes((n as u64).saturating_mul(4)))
     }
 
+    /// Storage: NodeWeightByChild iteration (r:n), NodeWeightLastBucket + ChildRegistrations
+    /// (r:n each), then per pruned child: NodeWeightByChild/NodeWeightLastBucket/NodeQualityByChild
+    /// removals (w:3) plus family weight sweep (r:1 w:3 worst case).
+    fn prune_stale_node_weights(n: u32) -> Weight {
+        Weight::from_parts(12_000_000, 0)
+            .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(n.into()))
+            .saturating_add(T::DbWeight::get().reads(1_u64.saturating_add((n as u64).saturating_mul(4))))
+            .saturating_add(T::DbWeight::get().writes((n as u64).saturating_mul(6)))
+    }
+
     /// Storage: Proxy Proxies (r:1+), Registration maps (iteration), UserTotalFilesSize (r:1 w:1),
     /// UserTotalFilesCount (r:1 w:1)
     fn update_user_file_size() -> Weight {
@@ -376,6 +387,13 @@ impl WeightInfo for () {
             .saturating_add(Weight::from_parts(4_000_000, 0).saturating_mul(n.into()))
             .saturating_add(RocksDbWeight::get().reads(1))
             .saturating_add(RocksDbWeight::get().writes((n as u64).saturating_mul(4)))
+    }
+
+    fn prune_stale_node_weights(n: u32) -> Weight {
+        Weight::from_parts(12_000_000, 0)
+            .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(n.into()))
+            .saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add((n as u64).saturating_mul(4))))
+            .saturating_add(RocksDbWeight::get().writes((n as u64).saturating_mul(6)))
     }
 
     fn update_user_file_size() -> Weight {

--- a/pallets/arion-pallet/src/weights.rs
+++ b/pallets/arion-pallet/src/weights.rs
@@ -234,14 +234,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().writes((n as u64).saturating_mul(4)))
     }
 
-    /// Storage: NodeWeightByChild iteration (r:n), NodeWeightLastBucket + ChildRegistrations
-    /// (r:n each), then per pruned child: NodeWeightByChild/NodeWeightLastBucket/NodeQualityByChild
-    /// removals (w:3) plus family weight sweep (r:1 w:3 worst case).
+    /// `n` = max_scan (upper bound on entries walked). Per scanned entry:
+    /// NodeWeightByChild iteration + NodeWeightLastBucket + ChildRegistrations reads;
+    /// per pruned child (<= n): weight-trio removals (w:3) plus family sweep
+    /// (r:1 w:3 worst case); plus cursor read/write.
     fn prune_stale_node_weights(n: u32) -> Weight {
         Weight::from_parts(12_000_000, 0)
             .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(n.into()))
-            .saturating_add(T::DbWeight::get().reads(1_u64.saturating_add((n as u64).saturating_mul(4))))
-            .saturating_add(T::DbWeight::get().writes((n as u64).saturating_mul(6)))
+            .saturating_add(T::DbWeight::get().reads(2_u64.saturating_add((n as u64).saturating_mul(4))))
+            .saturating_add(T::DbWeight::get().writes(1_u64.saturating_add((n as u64).saturating_mul(6))))
     }
 
     /// Storage: Proxy Proxies (r:1+), Registration maps (iteration), UserTotalFilesSize (r:1 w:1),
@@ -392,8 +393,8 @@ impl WeightInfo for () {
     fn prune_stale_node_weights(n: u32) -> Weight {
         Weight::from_parts(12_000_000, 0)
             .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(n.into()))
-            .saturating_add(RocksDbWeight::get().reads(1_u64.saturating_add((n as u64).saturating_mul(4))))
-            .saturating_add(RocksDbWeight::get().writes((n as u64).saturating_mul(6)))
+            .saturating_add(RocksDbWeight::get().reads(2_u64.saturating_add((n as u64).saturating_mul(4))))
+            .saturating_add(RocksDbWeight::get().writes(1_u64.saturating_add((n as u64).saturating_mul(6))))
     }
 
     fn update_user_file_size() -> Weight {

--- a/pallets/arion-pallet/src/weights.rs
+++ b/pallets/arion-pallet/src/weights.rs
@@ -33,7 +33,11 @@ const UPDATE_USER_FILE_SIZE_READ_BUDGET: u64 = 8_192;
 pub trait WeightInfo {
     fn submit_crush_map(n: u32) -> Weight;
     fn submit_miner_stats(n: u32) -> Weight;
-    fn submit_node_quality(n: u32) -> Weight;
+    /// `n` = quality rows in the batch. `families` / `children_per_family` bound the
+    /// family-weight recompute page, whose cost scales with their product and is not
+    /// implied by `n` — an unbounded recompute is what makes actual work outrun the
+    /// declared weight as the family set grows.
+    fn submit_node_quality(n: u32, families: u32, children_per_family: u32) -> Weight;
     fn submit_attestations(n: u32) -> Weight;
     fn submit_attestation_commitment() -> Weight;
     fn register_child() -> Weight;
@@ -46,7 +50,11 @@ pub trait WeightInfo {
     fn deregister_warden() -> Weight;
     fn prune_attestation_buckets(n: u32) -> Weight;
     fn prune_historical_crush_epochs(n: u32) -> Weight;
-    fn prune_stale_node_weights(n: u32) -> Weight;
+    /// `scan` = entries walked, `prune` = entries actually removed. Split because the
+    /// walk is bounded by `max_scan` while removals are bounded by the far smaller
+    /// `max_children`; keying writes on `scan` over-declares them by the ratio between
+    /// the two, reserving most of a block for writes that cannot happen.
+    fn prune_stale_node_weights(scan: u32, prune: u32) -> Weight;
     /// See [`UPDATE_USER_FILE_SIZE_READ_BUDGET`].
     fn update_user_file_size() -> Weight;
     /// `on_initialize` miner stats prune: bounded scan + protected-uid pass over registrations.
@@ -102,21 +110,30 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     /// Storage: Arion NodeWeightByChild (r:0 w:n)
     /// Storage: Arion FamilyWeight (r:n w:n) - read and write for each family
     /// Storage: Arion FamilyFirstSeenBucket (r:n w:0) - newcomer check
-    fn submit_node_quality(n: u32) -> Weight {
+    fn submit_node_quality(n: u32, families: u32, children_per_family: u32) -> Weight {
         // Base cost + per-node writes + family weight recalculation
         // Family weight calculation involves log2 operations and EMA
         // Reads: 1 base + n child registrations + n family weights + n first seen buckets
         // Writes: 1 base + n qualities + n node weights + n family weights
+        let child_slots = (families as u64).saturating_mul(children_per_family as u64);
         Weight::from_parts(20_000_000, 0)
             .saturating_add(Weight::from_parts(5_000_000, 0).saturating_mul(n.into()))
             .saturating_add(T::DbWeight::get().reads(1)) // CurrentWeightBucket
             .saturating_add(T::DbWeight::get().reads(n.into())) // ChildRegistrations
-            .saturating_add(T::DbWeight::get().reads(n.into())) // FamilyWeight reads
-            .saturating_add(T::DbWeight::get().reads(n.into())) // FamilyFirstSeenBucket
             .saturating_add(T::DbWeight::get().writes(1)) // CurrentWeightBucket
             .saturating_add(T::DbWeight::get().writes(n.into())) // NodeQuality
             .saturating_add(T::DbWeight::get().writes(n.into())) // NodeWeightByChild
-            .saturating_add(T::DbWeight::get().writes(n.into())) // FamilyWeight
+            // Family recompute page: per family the FamilyActiveChildren iteration,
+            // FamilyChildren, FamilyFirstSeenBucket and FamilyWeight reads; per child slot
+            // the ChildRegistrations + NodeWeightLastBucket + NodeQualityByChild reads that
+            // `compute_family_weight_from_nodes` performs. Writes are FamilyWeightRaw +
+            // FamilyWeight per family, plus the cursor.
+            .saturating_add(T::DbWeight::get().reads(1)) // FamilyRecomputeCursor
+            .saturating_add(T::DbWeight::get().reads((families as u64).saturating_mul(4)))
+            .saturating_add(T::DbWeight::get().reads(child_slots.saturating_mul(3)))
+            .saturating_add(T::DbWeight::get().writes(1)) // FamilyRecomputeCursor
+            .saturating_add(T::DbWeight::get().writes((families as u64).saturating_mul(2)))
+            .saturating_add(Weight::from_parts(2_000_000, 0).saturating_mul(child_slots))
     }
 
     /// Storage: Arion AuditResults (r:n w:n)
@@ -234,15 +251,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().writes((n as u64).saturating_mul(4)))
     }
 
-    /// `n` = max_scan (upper bound on entries walked). Per scanned entry:
-    /// NodeWeightByChild iteration + NodeWeightLastBucket + ChildRegistrations reads;
-    /// per pruned child (<= n): weight-trio removals (w:3) plus family sweep
-    /// (r:1 w:3 worst case); plus cursor read/write.
-    fn prune_stale_node_weights(n: u32) -> Weight {
+    /// Reads scale with `scan`: NodeWeightByChild iteration + NodeWeightLastBucket +
+    /// ChildRegistrations per scanned entry, plus a ChildRegistrations re-read and a
+    /// family lookup per pruned child, plus the cursor. Writes scale with `prune`
+    /// only: weight-trio removals (w:3) plus family sweep (w:3 worst case), plus the
+    /// cursor.
+    fn prune_stale_node_weights(scan: u32, prune: u32) -> Weight {
         Weight::from_parts(12_000_000, 0)
-            .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(n.into()))
-            .saturating_add(T::DbWeight::get().reads(2_u64.saturating_add((n as u64).saturating_mul(4))))
-            .saturating_add(T::DbWeight::get().writes(1_u64.saturating_add((n as u64).saturating_mul(6))))
+            .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(scan.into()))
+            .saturating_add(T::DbWeight::get().reads(
+                2_u64
+                    .saturating_add((scan as u64).saturating_mul(3))
+                    .saturating_add((prune as u64).saturating_mul(2)),
+            ))
+            .saturating_add(
+                T::DbWeight::get().writes(1_u64.saturating_add((prune as u64).saturating_mul(6))),
+            )
     }
 
     /// Storage: Proxy Proxies (r:1+), Registration maps (iteration), UserTotalFilesSize (r:1 w:1),
@@ -303,17 +327,21 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().writes((n as u64).saturating_mul(2)))
     }
 
-    fn submit_node_quality(n: u32) -> Weight {
+    fn submit_node_quality(n: u32, families: u32, children_per_family: u32) -> Weight {
+        let child_slots = (families as u64).saturating_mul(children_per_family as u64);
         Weight::from_parts(20_000_000, 0)
             .saturating_add(Weight::from_parts(5_000_000, 0).saturating_mul(n.into()))
             .saturating_add(RocksDbWeight::get().reads(1)) // CurrentWeightBucket
             .saturating_add(RocksDbWeight::get().reads(n.into())) // ChildRegistrations
-            .saturating_add(RocksDbWeight::get().reads(n.into())) // FamilyWeight reads
-            .saturating_add(RocksDbWeight::get().reads(n.into())) // FamilyFirstSeenBucket
             .saturating_add(RocksDbWeight::get().writes(1)) // CurrentWeightBucket
             .saturating_add(RocksDbWeight::get().writes(n.into())) // NodeQuality
             .saturating_add(RocksDbWeight::get().writes(n.into())) // NodeWeightByChild
-            .saturating_add(RocksDbWeight::get().writes(n.into())) // FamilyWeight
+            .saturating_add(RocksDbWeight::get().reads(1)) // FamilyRecomputeCursor
+            .saturating_add(RocksDbWeight::get().reads((families as u64).saturating_mul(4)))
+            .saturating_add(RocksDbWeight::get().reads(child_slots.saturating_mul(3)))
+            .saturating_add(RocksDbWeight::get().writes(1)) // FamilyRecomputeCursor
+            .saturating_add(RocksDbWeight::get().writes((families as u64).saturating_mul(2)))
+            .saturating_add(Weight::from_parts(2_000_000, 0).saturating_mul(child_slots))
     }
 
     fn submit_attestations(n: u32) -> Weight {
@@ -390,11 +418,17 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().writes((n as u64).saturating_mul(4)))
     }
 
-    fn prune_stale_node_weights(n: u32) -> Weight {
+    fn prune_stale_node_weights(scan: u32, prune: u32) -> Weight {
         Weight::from_parts(12_000_000, 0)
-            .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(n.into()))
-            .saturating_add(RocksDbWeight::get().reads(2_u64.saturating_add((n as u64).saturating_mul(4))))
-            .saturating_add(RocksDbWeight::get().writes(1_u64.saturating_add((n as u64).saturating_mul(6))))
+            .saturating_add(Weight::from_parts(6_000_000, 0).saturating_mul(scan.into()))
+            .saturating_add(RocksDbWeight::get().reads(
+                2_u64
+                    .saturating_add((scan as u64).saturating_mul(3))
+                    .saturating_add((prune as u64).saturating_mul(2)),
+            ))
+            .saturating_add(
+                RocksDbWeight::get().writes(1_u64.saturating_add((prune as u64).saturating_mul(6))),
+            )
     }
 
     fn update_user_file_size() -> Weight {

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -203,6 +203,10 @@ pub mod pallet {
 		/// Max number of user file-usage rows that can be updated in a single batch call.
 		#[pallet::constant]
 		type MaxUserFileUsageUpdatesPerCall: Get<u32>;
+
+		/// Max number of users a single `create_referral_codes_for` call may cover.
+		#[pallet::constant]
+		type MaxReferralCodesPerCall: Get<u32>;
     }
 
 	// const LOCK_BLOCK_EXPIRATION: u32 = 3;
@@ -501,6 +505,16 @@ pub mod pallet {
 			drive_count: u128,
 			s3_size: u128,
 			s3_count: u128,
+		},
+		/// A referral code was created for `user` by a whitelisted caller.
+		ReferralCodeCreatedFor {
+			user: T::AccountId,
+		},
+		/// Summary of a `create_referral_codes_for` batch. `skipped` counts users
+		/// that already had a code and were left untouched.
+		ReferralCodesCreatedFor {
+			created: u32,
+			skipped: u32,
 		},
 		WhitelistedCallerAdded {
 			account: T::AccountId,
@@ -1182,6 +1196,54 @@ pub mod pallet {
 			ensure_root(origin)?;
 			ReferralBankFloor::<T>::put(floor);
 			Self::deposit_event(Event::ReferralBankFloorUpdated { floor });
+			Ok(())
+		}
+
+		/// Create referral codes on behalf of users. Callable only by a whitelisted caller,
+		/// bounded by `MaxReferralCodesPerCall`.
+		///
+		/// Idempotent: users that already hold a referral code are skipped, not issued a
+		/// second one. `pallet_credits::do_change_referral_code` always mints a *new* code
+		/// and deliberately never deletes the old one, so calling it for an existing holder
+		/// would proliferate codes — and would fail outright with `ReferralCodeCooldown`
+		/// inside the per-user cooldown window. Skipping keeps retries and backfill sweeps
+		/// safe to repeat.
+		#[pallet::call_index(29)]
+		#[pallet::weight((10_000, Pays::No))]
+		pub fn create_referral_codes_for(
+			origin: OriginFor<T>,
+			users: Vec<T::AccountId>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let allowed = WhitelistedCallers::<T>::get();
+			ensure!(allowed.contains(&who), Error::<T>::WhitelistedCallerNotAuthorized);
+
+			ensure!(
+				(users.len() as u32) <= T::MaxReferralCodesPerCall::get(),
+				Error::<T>::TooManyUpdates
+			);
+
+			let mut created: u32 = 0;
+			let mut skipped: u32 = 0;
+
+			for user in users {
+				// `LastReferralCreationBlock` is written by `do_change_referral_code`, the only
+				// path that inserts into `ReferralCodes`, so its presence is an exact
+				// "already has a code" test. A user repeated within one batch is also caught
+				// here: the first iteration sets the block, later ones skip.
+				if CreditsPallet::<T>::last_referral_creation_block(&user).is_some() {
+					skipped = skipped.saturating_add(1);
+					continue;
+				}
+
+				CreditsPallet::<T>::do_change_referral_code(user.clone())?;
+				created = created.saturating_add(1);
+				Self::deposit_event(Event::ReferralCodeCreatedFor { user });
+			}
+
+			Self::deposit_event(Event::ReferralCodesCreatedFor { created, skipped });
+
 			Ok(())
 		}
 	}

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -100,6 +100,8 @@ parameter_types! {
 	pub const MaxCrushEpochPrunesPerCall: u32 = 200;
 	/// Cap on `prune_attestation_buckets` batch size (weight + anti-spam).
 	pub const MaxAttestationBucketsPrunePerCall: u32 = 64;
+	/// Cap on `prune_stale_node_weights` batch size (weight bound).
+	pub const MaxNodeWeightPrunePerCall: u32 = 200;
 	/// Periodic [`MinerStatsByUid`] pruning in arion (`0` = disabled).
 	pub const ArionMinerStatsPruneInterval: BlockNumber = 100;
 	/// Max stats uid keys scanned per pruning tick.
@@ -202,6 +204,7 @@ impl pallet_arion::Config for Runtime {
 	type MaxContentHashLen = ConstU32<32>;
 	type AttestationRetentionBuckets = ConstU32<168>;
 	type MaxAttestationBucketsPrunePerCall = MaxAttestationBucketsPrunePerCall;
+	type MaxNodeWeightPrunePerCall = MaxNodeWeightPrunePerCall;
 	type WeightInfo = pallet_arion::weights::SubstrateWeight<Runtime>;
 	type MaxAttestations = ConstU32<1000>;
 	type MaxShardHashLen = ConstU32<100>;
@@ -354,7 +357,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92001,
+	spec_version: 92002,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -104,6 +104,12 @@ parameter_types! {
 	pub const MaxNodeWeightPrunePerCall: u32 = 200;
 	/// Cap on `prune_stale_node_weights` scan size (bounds the walk over live entries).
 	pub const MaxNodeWeightScanPerCall: u32 = 2000;
+	/// Families visited per `submit_node_quality` recompute page. Declared weight scales
+	/// with this times `MaxChildrenPerFamily` (35), so 25 keeps a single call's family
+	/// term near 2.6k reads. The submitter issues many calls per bucket (batches are
+	/// capped at `MaxNodeWeightUpdates`), so the cursor still covers the whole family set
+	/// well inside a bucket at realistic sizes.
+	pub const MaxFamilyRecomputePerCall: u32 = 25;
 	/// Periodic [`MinerStatsByUid`] pruning in arion (`0` = disabled).
 	pub const ArionMinerStatsPruneInterval: BlockNumber = 100;
 	/// Max stats uid keys scanned per pruning tick.
@@ -208,6 +214,7 @@ impl pallet_arion::Config for Runtime {
 	type MaxAttestationBucketsPrunePerCall = MaxAttestationBucketsPrunePerCall;
 	type MaxNodeWeightPrunePerCall = MaxNodeWeightPrunePerCall;
 	type MaxNodeWeightScanPerCall = MaxNodeWeightScanPerCall;
+	type MaxFamilyRecomputePerCall = MaxFamilyRecomputePerCall;
 	type WeightInfo = pallet_arion::weights::SubstrateWeight<Runtime>;
 	type MaxAttestations = ConstU32<1000>;
 	type MaxShardHashLen = ConstU32<100>;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -810,6 +810,8 @@ parameter_types! {
 	pub const BlockChargeCheckInterval: u32 = 8;
 	pub const MaxRequestsPerBlock: u32 = 5;
 	pub const MaxUserFileUsageUpdatesPerCall: u32 = 250;
+	/// Cap on `create_referral_codes_for` batch size.
+	pub const MaxReferralCodesPerCall: u32 = 250;
 }
 
 impl pallet_marketplace::Config for Runtime {
@@ -828,6 +830,7 @@ impl pallet_marketplace::Config for Runtime {
 	type AuthorityId = pallet_marketplace::crypto::TestAuthId;
 	type MaxRequestsPerBlock = MaxRequestsPerBlock;
 	type MaxUserFileUsageUpdatesPerCall = MaxUserFileUsageUpdatesPerCall;
+	type MaxReferralCodesPerCall = MaxReferralCodesPerCall;
 }
 
 parameter_types! {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -229,8 +229,10 @@ impl pallet_arion::Config for Runtime {
 	type MaxNodeWeightUpdates = MaxNodeWeightUpdates;
 	type MaxNodeWeight = MaxNodeWeight;
 	type MaxFamilyWeight = MaxFamilyWeight;
-	type FamilyTopN = FamilyTopN;
-	type FamilyRankDecayPermille = FamilyRankDecayPermille;
+	type FamilyScoreFloorBytes = FamilyScoreFloorBytes;
+	type FamilyScoreCeilBytes = FamilyScoreCeilBytes;
+	type MaxFamilyScore = MaxFamilyScore;
+	type StaleChildBuckets = StaleChildBuckets;
 	type FamilyWeightEmaAlphaPermille = FamilyWeightEmaAlphaPermille;
 	type MaxFamilyWeightDeltaPerBucket = MaxFamilyWeightDeltaPerBucket;
 	type NewcomerGraceBuckets = NewcomerGraceBuckets;
@@ -354,7 +356,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92001,
+	spec_version: 92002,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`
@@ -397,10 +399,14 @@ parameter_types! {
 	pub const MaxNodeWeight: u16 = 50_000;
 	// Maximum family weight
 	pub const MaxFamilyWeight: u16 = 65_535;
-	// Number of top nodes to consider per family
-	pub const FamilyTopN: u32 = 10;
-	// Decay factor for family rank (permille)
-	pub const FamilyRankDecayPermille: u32 = 800;
+	// Aggregate family scoring range: 0 at 100 GiB, MaxFamilyScore at 1 PiB
+	pub const FamilyScoreFloorBytes: u128 = 100 * (1u128 << 30);
+	pub const FamilyScoreCeilBytes: u128 = 1u128 << 50;
+	// Max achievable family score — strictly below MaxFamilyWeight (u16::MAX)
+	// so families can never sit saturated at the storage-type ceiling.
+	pub const MaxFamilyScore: u16 = 60_000;
+	// Children not refreshed for more than this many buckets stop counting.
+	pub const StaleChildBuckets: u32 = 4;
 	// EMA alpha for family weight (permille)
 	pub const FamilyWeightEmaAlphaPermille: u32 = 300;
 	// Maximum family weight delta per bucket

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -102,6 +102,8 @@ parameter_types! {
 	pub const MaxAttestationBucketsPrunePerCall: u32 = 64;
 	/// Cap on `prune_stale_node_weights` batch size (weight bound).
 	pub const MaxNodeWeightPrunePerCall: u32 = 200;
+	/// Cap on `prune_stale_node_weights` scan size (bounds the walk over live entries).
+	pub const MaxNodeWeightScanPerCall: u32 = 2000;
 	/// Periodic [`MinerStatsByUid`] pruning in arion (`0` = disabled).
 	pub const ArionMinerStatsPruneInterval: BlockNumber = 100;
 	/// Max stats uid keys scanned per pruning tick.
@@ -205,6 +207,7 @@ impl pallet_arion::Config for Runtime {
 	type AttestationRetentionBuckets = ConstU32<168>;
 	type MaxAttestationBucketsPrunePerCall = MaxAttestationBucketsPrunePerCall;
 	type MaxNodeWeightPrunePerCall = MaxNodeWeightPrunePerCall;
+	type MaxNodeWeightScanPerCall = MaxNodeWeightScanPerCall;
 	type WeightInfo = pallet_arion::weights::SubstrateWeight<Runtime>;
 	type MaxAttestations = ConstU32<1000>;
 	type MaxShardHashLen = ConstU32<100>;

--- a/runtime/mainnet/tests/family_weight_aggregate.rs
+++ b/runtime/mainnet/tests/family_weight_aggregate.rs
@@ -278,3 +278,147 @@ fn below_floor_scores_zero() {
 		assert_eq!(raw(&fam), 0);
 	});
 }
+
+/// Same as `quality`, but carrying strikes/integrity failures.
+fn quality_penalized(bytes: u128, uptime: u16, strikes: u32, integrity_fails: u32) -> NodeQuality {
+	NodeQuality {
+		shard_data_bytes: bytes,
+		bandwidth_bytes: 0,
+		uptime_permille: uptime,
+		strikes,
+		integrity_fails,
+	}
+}
+
+#[test]
+fn fragmentation_is_neutral_with_penalties() {
+	new_test_ext().execute_with(|| {
+		// The invariance `fragmentation_is_neutral` proves at zero penalties must also
+		// hold when every node carries the same penalty load. Summing penalties across
+		// children breaks it: the base score is logarithmic in AGGREGATE bytes and so is
+		// unchanged by splitting, but a summed penalty scales with child count, making
+		// four 1 TiB nodes cost 4x what one 4 TiB node costs for identical data+strikes.
+		let fam_a = account(80, 0);
+		let fam_b = account(81, 0);
+
+		let a1 = account(80, 10);
+		add_child(&fam_a, &a1);
+		let mut pairs = vec![(a1, quality_penalized(4 * TIB, 900, 1, 0))];
+
+		for i in 0..4u8 {
+			let c = account(81, 10 + i);
+			add_child(&fam_b, &c);
+			pairs.push((c, quality_penalized(TIB, 900, 1, 0)));
+		}
+		submit(pairs);
+
+		assert_eq!(
+			raw(&fam_a),
+			raw(&fam_b),
+			"same bytes and same per-node penalty must score identically regardless of split"
+		);
+		assert!(raw(&fam_a) > 0, "penalty must not wipe the score out entirely");
+	});
+}
+
+#[test]
+fn penalties_still_reduce_the_score() {
+	new_test_ext().execute_with(|| {
+		// Averaging must not neuter penalties: a penalized family still scores strictly
+		// below an identical clean one, and integrity failures bite harder than strikes
+		// (IntegrityFailPenalty 100 vs StrikePenalty 50).
+		let clean = account(82, 0);
+		let struck = account(83, 0);
+		let broken = account(84, 0);
+
+		let c1 = account(82, 10);
+		let c2 = account(83, 10);
+		let c3 = account(84, 10);
+		add_child(&clean, &c1);
+		add_child(&struck, &c2);
+		add_child(&broken, &c3);
+
+		submit(vec![
+			(c1, quality_penalized(10 * TIB, 1000, 0, 0)),
+			(c2, quality_penalized(10 * TIB, 1000, 1, 0)),
+			(c3, quality_penalized(10 * TIB, 1000, 0, 1)),
+		]);
+
+		assert!(raw(&clean) > raw(&struck), "a strike must cost something");
+		assert!(raw(&struck) > raw(&broken), "an integrity fail must cost more than a strike");
+	});
+}
+
+#[test]
+fn one_bad_node_among_many_dilutes() {
+	new_test_ext().execute_with(|| {
+		// A single bad node in a four-node family should cost less than the same node
+		// standing alone — the family is mostly healthy. This is the behaviour that
+		// distinguishes averaging from summing, which would charge both identically.
+		let solo = account(85, 0);
+		let mixed = account(86, 0);
+
+		let s1 = account(85, 10);
+		add_child(&solo, &s1);
+		let mut pairs = vec![(s1, quality_penalized(TIB, 1000, 4, 0))];
+
+		// Same aggregate bytes, same total strikes, spread over four nodes.
+		for i in 0..4u8 {
+			let c = account(86, 10 + i);
+			add_child(&mixed, &c);
+			let strikes = if i == 0 { 4 } else { 0 };
+			pairs.push((c, quality_penalized(TIB / 4, 1000, strikes, 0)));
+		}
+		submit(pairs);
+
+		assert!(
+			raw(&mixed) > raw(&solo),
+			"the same strike load spread over more healthy nodes must hurt less: \
+			 mixed={} solo={}",
+			raw(&mixed),
+			raw(&solo)
+		);
+	});
+}
+
+#[test]
+fn family_recompute_pages_across_calls() {
+	new_test_ext().execute_with(|| {
+		// MaxFamilyRecomputePerCall is 25 on mainnet. With more families than that, one
+		// call cannot cover them all — the cursor must carry the walk forward so repeated
+		// calls reach every family. This is what keeps the recompute inside its declared
+		// weight without permanently starving families outside the first page.
+		let mut fams = Vec::new();
+		let mut pairs = Vec::new();
+		for i in 0..40u8 {
+			let fam = account(100 + i, 0);
+			let child = account(100 + i, 200);
+			add_child(&fam, &child);
+			pairs.push((child, quality(10 * TIB, 0, 1000)));
+			fams.push(fam);
+		}
+
+		// Seed every family's weight in one submit batch. The batch itself is capped by
+		// MaxNodeWeightUpdates (100), so all 40 children land in a single call.
+		submit(pairs);
+
+		let scored_after_first = fams.iter().filter(|f| raw(f) > 0).count();
+		assert!(
+			scored_after_first < fams.len(),
+			"a single page must not cover all 40 families (cap is 25), got {scored_after_first}"
+		);
+
+		// Keep calling with an empty batch: the recompute page advances on the cursor
+		// alone, so coverage must reach every family.
+		for _ in 0..4 {
+			submit(vec![]);
+		}
+
+		let scored_after_paging = fams.iter().filter(|f| raw(f) > 0).count();
+		assert_eq!(
+			scored_after_paging,
+			fams.len(),
+			"cursor must eventually cover every family"
+		);
+	});
+}

--- a/runtime/mainnet/tests/family_weight_aggregate.rs
+++ b/runtime/mainnet/tests/family_weight_aggregate.rs
@@ -1,0 +1,280 @@
+//! Tests for the aggregate family weight formula.
+//!
+//! The family score is computed from the AGGREGATE bytes of its fresh Active
+//! children (not a sum of per-node scores), normalized over the useful range
+//! [FamilyScoreFloorBytes, FamilyScoreCeilBytes] and capped at MaxFamilyScore
+//! (< MaxFamilyWeight). Assertions read `FamilyWeightRaw` — the raw computed
+//! value — because `FamilyWeight` is EMA-smoothed and delta-clamped.
+
+use frame_support::assert_ok;
+use hippius_mainnet_runtime::{AccountId, Arion, Runtime, RuntimeOrigin, System};
+use pallet_arion::{
+	ChildRegistration, ChildRegistrations, ChildStatus, CurrentWeightBucket, FamilyActiveChildren,
+	FamilyChildren, FamilyWeightRaw, NodeQuality, NodeQualityByChild, NodeWeightLastBucket,
+};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{AccountId32, BuildStorage};
+
+const BUCKET: u32 = 100;
+const TIB: u128 = 1024 * 1024 * 1024 * 1024;
+
+/// Whitelisted `ArionAdminMembers` account (WeightAuthorityOrigin).
+fn admin() -> AccountId {
+	AccountId32::from_ss58check("5CVXqxb7mhFTtZVw5BJ8M2ujND9PFymSDxF8bkod6Sm4XJTW").unwrap()
+}
+
+fn account(seed: u8, tag: u8) -> AccountId {
+	let mut raw = [seed; 32];
+	raw[0] = tag;
+	AccountId32::new(raw)
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		CurrentWeightBucket::<Runtime>::put(BUCKET);
+	});
+	ext
+}
+
+fn quality(bytes: u128, bw: u128, uptime: u16) -> NodeQuality {
+	NodeQuality {
+		shard_data_bytes: bytes,
+		bandwidth_bytes: bw,
+		uptime_permille: uptime,
+		strikes: 0,
+		integrity_fails: 0,
+	}
+}
+
+/// Register a child under a family and add it to the family index.
+fn add_child(family: &AccountId, child: &AccountId) {
+	let node_id: [u8; 32] = child.clone().into();
+	ChildRegistrations::<Runtime>::insert(
+		child,
+		ChildRegistration {
+			family: family.clone(),
+			node_id,
+			status: ChildStatus::Active,
+			deposit: 0u128,
+			unbonding_end: 0u32.into(),
+		},
+	);
+	FamilyChildren::<Runtime>::mutate(family, |v| {
+		v.try_push(child.clone()).expect("under MaxChildrenPerFamily");
+	});
+	FamilyActiveChildren::<Runtime>::mutate(family, |n| *n += 1);
+}
+
+/// Submit quality for the given (child, quality) pairs and trigger the recompute.
+fn submit(pairs: Vec<(AccountId, NodeQuality)>) {
+	let updates: Vec<(AccountId, NodeQuality)> = pairs;
+	assert_ok!(Arion::submit_node_quality(
+		RuntimeOrigin::signed(admin()),
+		BUCKET,
+		updates.try_into().expect("under MaxNodeWeightUpdates"),
+	));
+}
+
+fn raw(family: &AccountId) -> u16 {
+	FamilyWeightRaw::<Runtime>::get(family)
+}
+
+#[test]
+fn fragmentation_is_neutral() {
+	new_test_ext().execute_with(|| {
+		// Family A: one node with 4 TiB. Family B: four nodes with 1 TiB each.
+		let fam_a = account(1, 0);
+		let fam_b = account(2, 0);
+		let a1 = account(1, 10);
+		add_child(&fam_a, &a1);
+		let mut pairs = vec![(a1, quality(4 * TIB, 0, 900))];
+		for i in 0..4u8 {
+			let c = account(2, 10 + i);
+			add_child(&fam_b, &c);
+			pairs.push((c, quality(TIB, 0, 900)));
+		}
+		submit(pairs);
+
+		assert_eq!(raw(&fam_a), raw(&fam_b), "same total bytes must score identically");
+		assert!(raw(&fam_a) > 0);
+	});
+}
+
+#[test]
+fn strictly_monotonic_in_bytes() {
+	new_test_ext().execute_with(|| {
+		let sizes = [TIB, 10 * TIB, 100 * TIB];
+		let mut pairs = Vec::new();
+		let mut fams = Vec::new();
+		for (i, sz) in sizes.iter().enumerate() {
+			let fam = account(10 + i as u8, 0);
+			let c = account(10 + i as u8, 1);
+			add_child(&fam, &c);
+			pairs.push((c, quality(*sz, 0, 1000)));
+			fams.push(fam);
+		}
+		submit(pairs);
+
+		let (w1, w10, w100) = (raw(&fams[0]), raw(&fams[1]), raw(&fams[2]));
+		assert!(w1 < w10 && w10 < w100, "ranking must exist: {w1} < {w10} < {w100}");
+	});
+}
+
+#[test]
+fn never_reaches_the_type_ceiling() {
+	new_test_ext().execute_with(|| {
+		// 10 children of 100 TiB (~1 PiB aggregate = the calibration ceiling),
+		// maximum bandwidth, perfect uptime.
+		let fam = account(20, 0);
+		let mut pairs = Vec::new();
+		for i in 0..10u8 {
+			let c = account(20, 10 + i);
+			add_child(&fam, &c);
+			pairs.push((c, quality(100 * TIB, 100 * TIB, 1000)));
+		}
+		submit(pairs);
+
+		let w = raw(&fam);
+		let max_score = 60_000u16; // runtime MaxFamilyScore
+		assert!(w <= max_score, "raw {w} must not exceed MaxFamilyScore");
+		assert!(w < u16::MAX, "families must never sit at the u16 ceiling");
+		assert!(w > 50_000, "a ceiling-range family should still score near the top: {w}");
+	});
+}
+
+#[test]
+fn absurd_inputs_do_not_overflow() {
+	new_test_ext().execute_with(|| {
+		// u128::MAX everywhere: must not panic, must stay bounded.
+		let fam = account(30, 0);
+		let mut pairs = Vec::new();
+		for i in 0..3u8 {
+			let c = account(30, 10 + i);
+			add_child(&fam, &c);
+			pairs.push((
+				c,
+				NodeQuality {
+					shard_data_bytes: u128::MAX,
+					bandwidth_bytes: u128::MAX,
+					uptime_permille: u16::MAX, // > 1000, must be clamped
+					strikes: 0,
+					integrity_fails: 0,
+				},
+			));
+		}
+		submit(pairs);
+		assert!(raw(&fam) <= 60_000);
+
+		// Max penalties: must saturate to zero, not underflow.
+		let fam2 = account(31, 0);
+		let c2 = account(31, 10);
+		add_child(&fam2, &c2);
+		submit(vec![(
+			c2,
+			NodeQuality {
+				shard_data_bytes: 10 * TIB,
+				bandwidth_bytes: 0,
+				uptime_permille: 1000,
+				strikes: u32::MAX,
+				integrity_fails: u32::MAX,
+			},
+		)]);
+		assert_eq!(raw(&fam2), 0);
+	});
+}
+
+#[test]
+fn dust_children_add_nothing() {
+	new_test_ext().execute_with(|| {
+		let fam_solo = account(40, 0);
+		let solo = account(40, 10);
+		add_child(&fam_solo, &solo);
+		let mut pairs = vec![(solo, quality(10 * TIB, 0, 900))];
+
+		// Same bytes plus 30 dust children of 1 byte each.
+		let fam_dust = account(41, 0);
+		let big = account(41, 10);
+		add_child(&fam_dust, &big);
+		pairs.push((big, quality(10 * TIB, 0, 900)));
+		for i in 0..30u8 {
+			let c = account(41, 50 + i);
+			add_child(&fam_dust, &c);
+			pairs.push((c, quality(1, 0, 900)));
+		}
+		submit(pairs);
+
+		let diff = raw(&fam_dust).abs_diff(raw(&fam_solo));
+		assert!(diff <= 1, "30 dust children changed the score by {diff}");
+	});
+}
+
+#[test]
+fn stale_children_stop_counting() {
+	new_test_ext().execute_with(|| {
+		// Family with one fresh and one stale child of equal size: the stale one
+		// must contribute nothing, so the family scores like the fresh child alone.
+		let fam = account(50, 0);
+		let fresh = account(50, 10);
+		let stale = account(50, 11);
+		add_child(&fam, &fresh);
+		add_child(&fam, &stale);
+		// Stale child: quality present but last refreshed 10 buckets ago (> StaleChildBuckets=4).
+		NodeQualityByChild::<Runtime>::insert(&stale, quality(10 * TIB, 0, 1000));
+		NodeWeightLastBucket::<Runtime>::insert(&stale, BUCKET - 10);
+
+		let fam_ref = account(51, 0);
+		let only = account(51, 10);
+		add_child(&fam_ref, &only);
+
+		submit(vec![
+			(fresh, quality(10 * TIB, 0, 1000)),
+			(only, quality(10 * TIB, 0, 1000)),
+		]);
+
+		assert_eq!(raw(&fam), raw(&fam_ref), "stale child must contribute zero");
+
+		// Family whose ONLY child went stale: raw collapses to 0.
+		let fam_dead = account(52, 0);
+		let dead = account(52, 10);
+		add_child(&fam_dead, &dead);
+		NodeQualityByChild::<Runtime>::insert(&dead, quality(10 * TIB, 0, 1000));
+		NodeWeightLastBucket::<Runtime>::insert(&dead, BUCKET - 10);
+		// Trigger a recompute via an unrelated submission.
+		submit(vec![(account(51, 10), quality(10 * TIB, 0, 1000))]);
+		assert_eq!(raw(&fam_dead), 0);
+	});
+}
+
+#[test]
+fn uptime_scales_the_score() {
+	new_test_ext().execute_with(|| {
+		let fam_hi = account(60, 0);
+		let hi = account(60, 10);
+		add_child(&fam_hi, &hi);
+		let fam_lo = account(61, 0);
+		let lo = account(61, 10);
+		add_child(&fam_lo, &lo);
+		submit(vec![
+			(hi, quality(10 * TIB, 0, 1000)),
+			(lo, quality(10 * TIB, 0, 500)),
+		]);
+		let (whi, wlo) = (raw(&fam_hi) as u32, raw(&fam_lo) as u32);
+		assert!(wlo * 2 >= whi.saturating_sub(2) && wlo * 2 <= whi + 2,
+			"uptime 500 should halve the score: hi={whi} lo={wlo}");
+	});
+}
+
+#[test]
+fn below_floor_scores_zero() {
+	new_test_ext().execute_with(|| {
+		// 10 GiB total is below the 100 GiB floor: no score.
+		let fam = account(70, 0);
+		let c = account(70, 10);
+		add_child(&fam, &c);
+		submit(vec![(c, quality(10 * 1024 * 1024 * 1024, 0, 1000))]);
+		assert_eq!(raw(&fam), 0);
+	});
+}

--- a/runtime/mainnet/tests/prune_stale_node_weights.rs
+++ b/runtime/mainnet/tests/prune_stale_node_weights.rs
@@ -1,0 +1,227 @@
+//! Tests for `Arion::prune_stale_node_weights`.
+//!
+//! The extrinsic removes per-child weight/quality entries left behind by
+//! children that are no longer `Active` (legacy deregistrations predating
+//! `remove_child_node_weight_entries`, expired unbondings), plus family
+//! weight entries of families with no active children left.
+
+use frame_support::{assert_noop, assert_ok};
+use hippius_mainnet_runtime::{AccountId, Arion, Runtime, RuntimeEvent, RuntimeOrigin, System};
+use pallet_arion::{
+	ChildRegistration, ChildRegistrations, ChildStatus, CurrentWeightBucket, FamilyActiveChildren,
+	FamilyFirstSeenBucket, FamilyWeight, FamilyWeightRaw, NodeQuality, NodeQualityByChild,
+	NodeWeightByChild, NodeWeightLastBucket,
+};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{AccountId32, BuildStorage};
+
+const CURRENT_BUCKET: u32 = 23_000;
+
+/// Whitelisted `ArionAdminMembers` account (WeightAuthorityOrigin).
+fn admin() -> AccountId {
+	AccountId32::from_ss58check("5CVXqxb7mhFTtZVw5BJ8M2ujND9PFymSDxF8bkod6Sm4XJTW").unwrap()
+}
+
+fn account(seed: u8) -> AccountId {
+	AccountId32::new([seed; 32])
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		CurrentWeightBucket::<Runtime>::put(CURRENT_BUCKET);
+	});
+	ext
+}
+
+fn quality(uptime: u16) -> NodeQuality {
+	NodeQuality {
+		shard_data_bytes: 1,
+		bandwidth_bytes: 1,
+		uptime_permille: uptime,
+		strikes: 0,
+		integrity_fails: 0,
+	}
+}
+
+/// Seed the weight trio for a child, `age` buckets behind the current bucket.
+fn seed_weight(child: &AccountId, weight: u16, age: u32) {
+	NodeWeightByChild::<Runtime>::insert(child, weight);
+	NodeWeightLastBucket::<Runtime>::insert(child, CURRENT_BUCKET.saturating_sub(age));
+	NodeQualityByChild::<Runtime>::insert(child, quality(900));
+}
+
+fn register(child: &AccountId, family: &AccountId, status: ChildStatus) {
+	let node_id: [u8; 32] = child.clone().into();
+	ChildRegistrations::<Runtime>::insert(
+		child,
+		ChildRegistration {
+			family: family.clone(),
+			node_id,
+			status,
+			deposit: 0u128,
+			unbonding_end: 0u32.into(),
+		},
+	);
+}
+
+fn last_prune_event() -> Option<(u32, u32)> {
+	System::events().iter().rev().find_map(|r| match &r.event {
+		RuntimeEvent::Arion(pallet_arion::Event::StaleNodeWeightsPruned {
+			children_pruned,
+			families_pruned,
+		}) => Some((*children_pruned, *families_pruned)),
+		_ => None,
+	})
+}
+
+#[test]
+fn prunes_stale_children_without_active_registration() {
+	new_test_ext().execute_with(|| {
+		let family = account(1);
+		// Legacy fossil: weight entries but no registration at all.
+		let ghost = account(10);
+		seed_weight(&ghost, 400, 500);
+		// Expired unbonding: registration present but not Active.
+		let unbonding = account(11);
+		seed_weight(&unbonding, 300, 500);
+		register(&unbonding, &family, ChildStatus::Unbonding);
+
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+
+		for child in [&ghost, &unbonding] {
+			assert!(!NodeWeightByChild::<Runtime>::contains_key(child));
+			assert!(!NodeWeightLastBucket::<Runtime>::contains_key(child));
+			assert!(!NodeQualityByChild::<Runtime>::contains_key(child));
+		}
+		assert_eq!(last_prune_event(), Some((2, 1)));
+	});
+}
+
+#[test]
+fn keeps_live_and_active_children() {
+	new_test_ext().execute_with(|| {
+		let family = account(1);
+		// Live child: refreshed this bucket (no registration needed to be safe).
+		let live = account(20);
+		seed_weight(&live, 500, 0);
+		// Stale but still Active: quality path owns it, prune must not touch it.
+		let stale_active = account(21);
+		seed_weight(&stale_active, 200, 500);
+		register(&stale_active, &family, ChildStatus::Active);
+		FamilyActiveChildren::<Runtime>::insert(&family, 1u32);
+
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+
+		assert_eq!(NodeWeightByChild::<Runtime>::get(&live), 500);
+		assert_eq!(NodeWeightByChild::<Runtime>::get(&stale_active), 200);
+		assert!(last_prune_event().is_none());
+	});
+}
+
+#[test]
+fn missing_last_bucket_counts_as_stale() {
+	new_test_ext().execute_with(|| {
+		let orphan = account(30);
+		// Weight + quality but no NodeWeightLastBucket entry (decodes as 0).
+		NodeWeightByChild::<Runtime>::insert(&orphan, 123u16);
+		NodeQualityByChild::<Runtime>::insert(&orphan, quality(500));
+
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+
+		assert!(!NodeWeightByChild::<Runtime>::contains_key(&orphan));
+		assert!(!NodeQualityByChild::<Runtime>::contains_key(&orphan));
+		assert_eq!(last_prune_event(), Some((1, 0)));
+	});
+}
+
+#[test]
+fn family_sweep_only_when_no_active_children() {
+	new_test_ext().execute_with(|| {
+		// Family A: its only child is Unbonding -> family weights swept.
+		let fam_a = account(1);
+		let child_a = account(40);
+		seed_weight(&child_a, 300, 500);
+		register(&child_a, &fam_a, ChildStatus::Unbonding);
+		FamilyActiveChildren::<Runtime>::insert(&fam_a, 0u32);
+		FamilyWeight::<Runtime>::insert(&fam_a, 50u16);
+		FamilyWeightRaw::<Runtime>::insert(&fam_a, 50u16);
+		FamilyFirstSeenBucket::<Runtime>::insert(&fam_a, 1u32);
+
+		// Family B: one stale Unbonding child pruned, but another Active child
+		// remains -> family weights must be kept.
+		let fam_b = account(2);
+		let child_b_dead = account(41);
+		seed_weight(&child_b_dead, 300, 500);
+		register(&child_b_dead, &fam_b, ChildStatus::Unbonding);
+		FamilyActiveChildren::<Runtime>::insert(&fam_b, 1u32);
+		FamilyWeight::<Runtime>::insert(&fam_b, 60u16);
+		FamilyWeightRaw::<Runtime>::insert(&fam_b, 60u16);
+
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+
+		assert!(!FamilyWeight::<Runtime>::contains_key(&fam_a));
+		assert!(!FamilyWeightRaw::<Runtime>::contains_key(&fam_a));
+		assert!(!FamilyFirstSeenBucket::<Runtime>::contains_key(&fam_a));
+		assert_eq!(FamilyWeight::<Runtime>::get(&fam_b), 60);
+		assert_eq!(FamilyWeightRaw::<Runtime>::get(&fam_b), 60);
+		assert_eq!(last_prune_event(), Some((2, 1)));
+	});
+}
+
+#[test]
+fn respects_max_children_cap() {
+	new_test_ext().execute_with(|| {
+		for seed in 50u8..60u8 {
+			seed_weight(&account(seed), 100, 500);
+		}
+
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 3));
+		assert_eq!(last_prune_event(), Some((3, 0)));
+
+		let remaining =
+			(50u8..60u8).filter(|s| NodeWeightByChild::<Runtime>::contains_key(&account(*s))).count();
+		assert_eq!(remaining, 7);
+
+		// A second call keeps draining the backlog.
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+		assert_eq!(last_prune_event(), Some((7, 0)));
+	});
+}
+
+#[test]
+fn rejects_non_authority_origin() {
+	new_test_ext().execute_with(|| {
+		seed_weight(&account(70), 100, 500);
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(account(99)), 4, 100),
+			sp_runtime::DispatchError::BadOrigin
+		);
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::root(), 4, 100),
+			sp_runtime::DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn validates_batch_and_staleness_params() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 0),
+			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
+		);
+		// MaxNodeWeightPrunePerCall is 200 on mainnet.
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 201),
+			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
+		);
+		// Staleness floor of 2 buckets protects live children.
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 1, 100),
+			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
+		);
+	});
+}

--- a/runtime/mainnet/tests/prune_stale_node_weights.rs
+++ b/runtime/mainnet/tests/prune_stale_node_weights.rs
@@ -89,7 +89,7 @@ fn prunes_stale_children_without_active_registration() {
 		seed_weight(&unbonding, 300, 500);
 		register(&unbonding, &family, ChildStatus::Unbonding);
 
-		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 1000));
 
 		for child in [&ghost, &unbonding] {
 			assert!(!NodeWeightByChild::<Runtime>::contains_key(child));
@@ -113,7 +113,7 @@ fn keeps_live_and_active_children() {
 		register(&stale_active, &family, ChildStatus::Active);
 		FamilyActiveChildren::<Runtime>::insert(&family, 1u32);
 
-		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 1000));
 
 		assert_eq!(NodeWeightByChild::<Runtime>::get(&live), 500);
 		assert_eq!(NodeWeightByChild::<Runtime>::get(&stale_active), 200);
@@ -129,7 +129,7 @@ fn missing_last_bucket_counts_as_stale() {
 		NodeWeightByChild::<Runtime>::insert(&orphan, 123u16);
 		NodeQualityByChild::<Runtime>::insert(&orphan, quality(500));
 
-		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 1000));
 
 		assert!(!NodeWeightByChild::<Runtime>::contains_key(&orphan));
 		assert!(!NodeQualityByChild::<Runtime>::contains_key(&orphan));
@@ -160,7 +160,7 @@ fn family_sweep_only_when_no_active_children() {
 		FamilyWeight::<Runtime>::insert(&fam_b, 60u16);
 		FamilyWeightRaw::<Runtime>::insert(&fam_b, 60u16);
 
-		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 1000));
 
 		assert!(!FamilyWeight::<Runtime>::contains_key(&fam_a));
 		assert!(!FamilyWeightRaw::<Runtime>::contains_key(&fam_a));
@@ -178,7 +178,7 @@ fn respects_max_children_cap() {
 			seed_weight(&account(seed), 100, 500);
 		}
 
-		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 3));
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 3, 1000));
 		assert_eq!(last_prune_event(), Some((3, 0)));
 
 		let remaining =
@@ -186,7 +186,7 @@ fn respects_max_children_cap() {
 		assert_eq!(remaining, 7);
 
 		// A second call keeps draining the backlog.
-		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100));
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 1000));
 		assert_eq!(last_prune_event(), Some((7, 0)));
 	});
 }
@@ -196,11 +196,11 @@ fn rejects_non_authority_origin() {
 	new_test_ext().execute_with(|| {
 		seed_weight(&account(70), 100, 500);
 		assert_noop!(
-			Arion::prune_stale_node_weights(RuntimeOrigin::signed(account(99)), 4, 100),
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(account(99)), 4, 100, 1000),
 			sp_runtime::DispatchError::BadOrigin
 		);
 		assert_noop!(
-			Arion::prune_stale_node_weights(RuntimeOrigin::root(), 4, 100),
+			Arion::prune_stale_node_weights(RuntimeOrigin::root(), 4, 100, 1000),
 			sp_runtime::DispatchError::BadOrigin
 		);
 	});
@@ -210,18 +210,74 @@ fn rejects_non_authority_origin() {
 fn validates_batch_and_staleness_params() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
-			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 0),
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 0, 1000),
 			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
 		);
 		// MaxNodeWeightPrunePerCall is 200 on mainnet.
 		assert_noop!(
-			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 201),
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 201, 1000),
 			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
 		);
 		// Staleness floor of 2 buckets protects live children.
 		assert_noop!(
-			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 1, 100),
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 1, 100, 1000),
 			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
 		);
+		// max_scan must cover max_children and respect MaxNodeWeightScanPerCall (2000).
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 50),
+			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
+		);
+		assert_noop!(
+			Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 100, 2001),
+			pallet_arion::Error::<Runtime>::InvalidNodeWeightPruneBatch
+		);
+	});
+}
+
+#[test]
+fn bounded_scan_pages_through_live_entries() {
+	new_test_ext().execute_with(|| {
+		use pallet_arion::NodeWeightPruneCursor;
+		// 12 LIVE children (fresh last_bucket, Active): nothing prunable, but the
+		// walk must stay bounded by max_scan and resume via the cursor.
+		let fam = account(80);
+		for seed in 0u8..12u8 {
+			let c = AccountId32::new([seed.wrapping_add(100); 32]);
+			seed_weight(&c, 100, 0);
+			ChildRegistrations::<Runtime>::insert(
+				&c,
+				ChildRegistration {
+					family: fam.clone(),
+					node_id: [seed; 32],
+					status: ChildStatus::Active,
+					deposit: 0u128,
+					unbonding_end: 0u32.into(),
+				},
+			);
+		}
+		// One stale ghost parked at the end of the walk (position depends on key
+		// hash; the three paged calls below must find it wherever it lands).
+		let ghost = account(81);
+		seed_weight(&ghost, 400, 500);
+
+		assert!(NodeWeightPruneCursor::<Runtime>::get().is_none());
+		// Page 1: scan 5 of 13 entries.
+		assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 4, 5));
+		assert!(NodeWeightPruneCursor::<Runtime>::get().is_some(), "cursor must park mid-map");
+		// Pages 2..: finish the map; cursor resets at the end.
+		for _ in 0..4 {
+			assert_ok!(Arion::prune_stale_node_weights(RuntimeOrigin::signed(admin()), 4, 4, 5));
+			if NodeWeightPruneCursor::<Runtime>::get().is_none() {
+				break;
+			}
+		}
+		assert!(NodeWeightPruneCursor::<Runtime>::get().is_none(), "cursor must reset after full pass");
+		assert!(!NodeWeightByChild::<Runtime>::contains_key(&ghost), "ghost pruned during paging");
+		// Live children untouched.
+		let live_left = (0u8..12u8)
+			.filter(|s| NodeWeightByChild::<Runtime>::contains_key(&AccountId32::new([s.wrapping_add(100); 32])))
+			.count();
+		assert_eq!(live_left, 12);
 	});
 }

--- a/vali-weights-submitter/mnemonic_wallet_helper.py
+++ b/vali-weights-submitter/mnemonic_wallet_helper.py
@@ -70,10 +70,12 @@ def test_mnemonic_wallet():
     if wallet:
         # Test connection to Bittensor
         try:
-            subtensor = bt.subtensor(network=config['bittensor']['chain_endpoint'])
-            balance = subtensor.get_balance(wallet.hotkey.ss58_address)
+            # bittensor v11: blocking Subtensor, balances namespace, close optional
+            subtensor = bt.Subtensor(network=config['bittensor']['chain_endpoint'])
+            balance = subtensor.balances.get(wallet.hotkey.ss58_address)
             print(f"✓ Wallet balance: {balance} TAO")
-            subtensor.close()
+            if hasattr(subtensor, "close"):
+                subtensor.close()
         except Exception as e:
             print(f"✗ Error checking balance: {e}")
 

--- a/vali-weights-submitter/requirements.txt
+++ b/vali-weights-submitter/requirements.txt
@@ -1,4 +1,4 @@
-bittensor>=9.10.0
+bittensor>=11.0.0
 substrate-interface>=1.7.0,<2.0.0
 pyyaml>=6.0
 numpy>=1.21.0

--- a/vali-weights-submitter/run_continuous.py
+++ b/vali-weights-submitter/run_continuous.py
@@ -49,7 +49,8 @@ class ContinuousWeightSubmitter:
         """Initialize Bittensor connection for block monitoring."""
         import bittensor as bt
         
-        self.subtensor = bt.subtensor(
+        # bittensor v11: bt.Subtensor is blocking when called directly
+        self.subtensor = bt.Subtensor(
             network=self.config['bittensor']['chain_endpoint']
         )
         self.logger.info("Initialized Bittensor connection for block monitoring")
@@ -73,7 +74,8 @@ class ContinuousWeightSubmitter:
             await self.initialize_subtensor()
         
         try:
-            block_number = self.subtensor.block
+            # bittensor v11: block is a method, not a property
+            block_number = self.subtensor.block()
             return block_number
         except Exception as e:
             self.logger.error(f"Error getting current block: {e}")
@@ -192,7 +194,8 @@ class ContinuousWeightSubmitter:
         """Stop the continuous submission process."""
         self.running = False
         self.logger.info("Stopping continuous weight submission...")
-        if self.subtensor:
+        # bittensor v11: close() is optional (auto on GC) and may not exist
+        if self.subtensor and hasattr(self.subtensor, "close"):
             self.subtensor.close()
 
 

--- a/vali-weights-submitter/setup_wallet.py
+++ b/vali-weights-submitter/setup_wallet.py
@@ -3,7 +3,7 @@
 Setup script to create a local wallet for weight submission
 """
 
-import bittensor as bt
+from bittensor.wallet import Wallet
 import os
 
 def setup_wallet():
@@ -41,7 +41,7 @@ def setup_wallet():
         print("Wallet location: ~/.bittensor/wallets/default/")
         
         # Load and display wallet info
-        wallet = bt.wallet(name="default", hotkey="default")
+        wallet = Wallet(name="default", hotkey="default")
         print(f"Hotkey SS58 address: {wallet.hotkey.ss58_address}")
         
         return True

--- a/vali-weights-submitter/sync_metagraph.py
+++ b/vali-weights-submitter/sync_metagraph.py
@@ -108,7 +108,8 @@ class StorageMonitor:
 
                 logger.info(f"Connecting to Bittensor chain using Bittensor library...")
                 # Use Bittensor library for Bittensor connection (same as run_continuous.py)
-                self.bittensor_chain = bt.subtensor(network="finney")  # Use mainnet
+                # bittensor v11: bt.Subtensor is blocking when called directly
+                self.bittensor_chain = bt.Subtensor(network="finney")  # Use mainnet
                 logger.info("✅ Connected to Bittensor chain using Bittensor library")
 
                 return True
@@ -170,25 +171,20 @@ class StorageMonitor:
     def get_uids_from_bittensor(self):
         """Fetch UIDs from Bittensor chain for net_uid 75"""
         try:
-            # Use Bittensor library's metagraph method (same as run_continuous.py)
-            metagraph = bt.metagraph(
-                netuid=self.net_uid,
-                subtensor=self.bittensor_chain
-            )
-            
-            # Get active neurons
-            active_neurons = metagraph.neurons
-            
+            # bittensor v11: metagraph lives under subnets namespace, neurons are typed records
+            metagraph = self.bittensor_chain.subnets.metagraph(netuid=self.net_uid)
+
             # Create mapping of UID to hotkey
+            # Note: no axon filter — subnet 75 miners don't serve axons, and the
+            # legacy code's `axon_info.ip != 0` check was a no-op (ip was a str)
             uids = []
-            for uid, neuron in enumerate(active_neurons):
-                if neuron.axon_info.ip != 0:  # Active neuron
-                    uids.append({
-                        "address": neuron.axon_info.hotkey,
-                        "id": uid,
-                        "role": "None",
-                        "substrate_address": neuron.axon_info.hotkey
-                    })
+            for neuron in metagraph:
+                uids.append({
+                    "address": neuron.hotkey,
+                    "id": neuron.uid,
+                    "role": "None",
+                    "substrate_address": neuron.hotkey
+                })
             
             logger.info(f"Fetched {len(uids)} active UIDs from Bittensor")
             return uids
@@ -200,17 +196,16 @@ class StorageMonitor:
     def get_dividends_from_bittensor(self):
         """Fetch dividends from Bittensor chain for net_uid 75"""
         try:
-            # Use Bittensor library's metagraph method to get dividends
-            metagraph = bt.metagraph(
-                netuid=self.net_uid,
-                subtensor=self.bittensor_chain
-            )
-            
-            # Get dividends from the metagraph
-            dividends = metagraph.dividends
-            if dividends is not None:
+            # bittensor v11: dividends are per-neuron fields, rebuild the uid-indexed list
+            metagraph = self.bittensor_chain.subnets.metagraph(netuid=self.net_uid)
+
+            neurons = list(metagraph)
+            if neurons:
+                dividends = [0.0] * (max(n.uid for n in neurons) + 1)
+                for n in neurons:
+                    dividends[n.uid] = float(n.dividends)
                 logger.info(f"Fetched {len(dividends)} dividends from Bittensor")
-                return list(dividends)
+                return dividends
             else:
                 logger.warning("No dividends found in metagraph")
                 return []

--- a/vali-weights-submitter/weight_submitter.py
+++ b/vali-weights-submitter/weight_submitter.py
@@ -19,7 +19,7 @@ os.environ['SSL_CERT_FILE'] = certifi.where()
 os.environ['SSL_CERT_DIR'] = certifi.where()
 
 import bittensor as bt
-from bittensor.core.extrinsics.set_weights import set_weights_extrinsic
+from bittensor.wallet import Wallet
 from substrateinterface import SubstrateInterface, Keypair
 
 
@@ -57,8 +57,8 @@ class WeightSubmitter:
         """Initialize connections to Bittensor and Hippius chain."""
         self.logger.info("Initializing connections...")
         
-        # Initialize Bittensor subtensor
-        self.subtensor = bt.subtensor(
+        # Initialize Bittensor subtensor (v11: blocking when called directly)
+        self.subtensor = bt.Subtensor(
             network=self.config['bittensor']['chain_endpoint']
         )
         
@@ -99,7 +99,7 @@ class WeightSubmitter:
         else:
             # Use local wallet files
             try:
-                self.wallet = bt.wallet(
+                self.wallet = Wallet(
                     name=self.config['wallet']['name'],
                     hotkey=self.config['wallet']['hotkey'],
                     path=self.config['wallet']['path']
@@ -134,20 +134,15 @@ class WeightSubmitter:
         self.logger.info(f"Fetching metagraph for subnet {self.config['bittensor']['subnet_id']}...")
         
         try:
-            # Get metagraph for the subnet
-            metagraph = bt.metagraph(
-                netuid=self.config['bittensor']['subnet_id'],
-                subtensor=self.subtensor
+            # v11: metagraph lives under the subnets namespace, neurons are typed records
+            metagraph = self.subtensor.subnets.metagraph(
+                netuid=self.config['bittensor']['subnet_id']
             )
-            
-            # Get active neurons
-            active_neurons = metagraph.neurons
-            
+
             # Create mapping of UID to hotkey
-            uid_to_hotkey = {}
-            for uid, neuron in enumerate(active_neurons):
-                if neuron.axon_info.ip != 0:  # Active neuron
-                    uid_to_hotkey[uid] = neuron.axon_info.hotkey
+            # Note: no axon filter — subnet 75 miners don't serve axons, and the
+            # legacy code's `axon_info.ip != 0` check was a no-op (ip was a str)
+            uid_to_hotkey = {neuron.uid: neuron.hotkey for neuron in metagraph}
             
             self.logger.info(f"Found {len(uid_to_hotkey)} active neurons in subnet {self.config['bittensor']['subnet_id']}")
             return uid_to_hotkey
@@ -346,20 +341,23 @@ class WeightSubmitter:
                 success = result.is_success
                 
             else:
-                # Local wallet - use Bittensor's set_weights_extrinsic
+                # Local wallet - v11: submit via SetWeights intent (normalization handled by SDK)
                 self.logger.info(f"Submitting weights using local wallet: {self.wallet.hotkey.ss58_address}")
-                
-                success = set_weights_extrinsic(
-                    subtensor=self.subtensor,
-                    wallet=self.wallet,
-                    netuid=self.config['bittensor']['subnet_id'],
-                    uids=uids_array,
-                    weights=weights_array,
-                    version_key=self.config['weights']['version_key'],
+
+                result = self.subtensor.execute(
+                    bt.SetWeights(
+                        netuid=self.config['bittensor']['subnet_id'],
+                        weights={uid: float(weight) for uid, weight in matched_weights},
+                        version_key=self.config['weights']['version_key']
+                    ),
+                    self.wallet,
                     wait_for_inclusion=self.config['weights']['wait_for_inclusion'],
                     wait_for_finalization=self.config['weights']['wait_for_finalization'],
                     period=self.config['weights']['period']
                 )
+                success = result.success
+                if not success and result.error is not None:
+                    self.logger.error(f"SetWeights failed: {result.error.name} - {result.error.remediation}")
             
             if success:
                 self.logger.info("Weights submitted successfully")
@@ -457,8 +455,8 @@ class WeightSubmitter:
             self.logger.error(f"Error in main execution: {e}")
             return False
         finally:
-            # Clean up connections
-            if self.subtensor:
+            # Clean up connections (v11: subtensor close is optional, auto on GC)
+            if self.subtensor and hasattr(self.subtensor, "close"):
                 self.subtensor.close()
             if self.hippius_interface:
                 self.hippius_interface.close()

--- a/vali-weights-submitter/weight_submitter_ss58_only.py
+++ b/vali-weights-submitter/weight_submitter_ss58_only.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Tuple, Optional
 import time
 
 import bittensor as bt
-from bittensor.core.extrinsics.set_weights import set_weights_extrinsic
+from bittensor.wallet import Wallet
 from substrateinterface import SubstrateInterface, Keypair
 
 
@@ -50,8 +50,8 @@ class WeightSubmitterSS58:
         """Initialize connections to Bittensor and Hippius chain."""
         self.logger.info("Initializing connections...")
         
-        # Initialize Bittensor subtensor
-        self.subtensor = bt.subtensor(
+        # Initialize Bittensor subtensor (v11: blocking when called directly)
+        self.subtensor = bt.Subtensor(
             network=self.config['bittensor']['chain_endpoint']
         )
         
@@ -70,7 +70,7 @@ class WeightSubmitterSS58:
             self.logger.info(f"Using SS58 address for querying: {self.validator_ss58}")
             
             # Still need a wallet for weight submission, but we'll use it minimally
-            self.wallet = bt.wallet(
+            self.wallet = Wallet(
                 name=self.config['wallet']['name'],
                 hotkey=self.config['wallet']['hotkey'],
                 path=self.config['wallet']['path']
@@ -78,7 +78,7 @@ class WeightSubmitterSS58:
             self.logger.info(f"Using local wallet for submission: {self.wallet.hotkey.ss58_address}")
         else:
             # Use local wallet for both querying and submission
-            self.wallet = bt.wallet(
+            self.wallet = Wallet(
                 name=self.config['wallet']['name'],
                 hotkey=self.config['wallet']['hotkey'],
                 path=self.config['wallet']['path']
@@ -98,20 +98,15 @@ class WeightSubmitterSS58:
         self.logger.info(f"Fetching metagraph for subnet {self.config['bittensor']['subnet_id']}...")
         
         try:
-            # Get metagraph for the subnet
-            metagraph = bt.metagraph(
-                netuid=self.config['bittensor']['subnet_id'],
-                subtensor=self.subtensor
+            # v11: metagraph lives under the subnets namespace, neurons are typed records
+            metagraph = self.subtensor.subnets.metagraph(
+                netuid=self.config['bittensor']['subnet_id']
             )
-            
-            # Get active neurons
-            active_neurons = metagraph.neurons
-            
+
             # Create mapping of UID to hotkey
-            uid_to_hotkey = {}
-            for uid, neuron in enumerate(active_neurons):
-                if neuron.axon_info.ip != 0:  # Active neuron
-                    uid_to_hotkey[uid] = neuron.axon_info.hotkey
+            # Note: no axon filter — subnet 75 miners don't serve axons, and the
+            # legacy code's `axon_info.ip != 0` check was a no-op (ip was a str)
+            uid_to_hotkey = {neuron.uid: neuron.hotkey for neuron in metagraph}
             
             self.logger.info(f"Found {len(uid_to_hotkey)} active neurons in subnet {self.config['bittensor']['subnet_id']}")
             return uid_to_hotkey
@@ -213,27 +208,21 @@ class WeightSubmitterSS58:
         self.logger.info(f"Submitting weights for {len(matched_weights)} neurons...")
         
         try:
-            # Extract UIDs and weights
-            uids = [uid for uid, _ in matched_weights]
-            weights = [weight for _, weight in matched_weights]
-            
-            # Convert to numpy arrays as expected by the function
-            uids_array = np.array(uids, dtype=np.int64)
-            weights_array = np.array(weights, dtype=np.float32)
-            
-            # Submit weights using the bittensor function
-            # Note: We still need a wallet for submission, but we can use the SS58 for querying
-            success = set_weights_extrinsic(
-                subtensor=self.subtensor,
-                wallet=self.wallet,
-                netuid=self.config['bittensor']['subnet_id'],
-                uids=uids_array,
-                weights=weights_array,
-                version_key=self.config['weights']['version_key'],
+            # v11: submit via SetWeights intent (normalization handled by SDK)
+            result = self.subtensor.execute(
+                bt.SetWeights(
+                    netuid=self.config['bittensor']['subnet_id'],
+                    weights={uid: float(weight) for uid, weight in matched_weights},
+                    version_key=self.config['weights']['version_key']
+                ),
+                self.wallet,
                 wait_for_inclusion=self.config['weights']['wait_for_inclusion'],
                 wait_for_finalization=self.config['weights']['wait_for_finalization'],
                 period=self.config['weights']['period']
             )
+            success = result.success
+            if not success and result.error is not None:
+                self.logger.error(f"SetWeights failed: {result.error.name} - {result.error.remediation}")
             
             if success:
                 self.logger.info("Weights submitted successfully")
@@ -278,8 +267,8 @@ class WeightSubmitterSS58:
             self.logger.error(f"Error in main execution: {e}")
             raise
         finally:
-            # Clean up connections
-            if self.subtensor:
+            # Clean up connections (v11: subtensor close is optional, auto on GC)
+            if self.subtensor and hasattr(self.subtensor, "close"):
                 self.subtensor.close()
             if self.hippius_interface:
                 self.hippius_interface.close()


### PR DESCRIPTION
## Problem

`NodeWeightByChild` / `NodeQualityByChild` / `NodeWeightLastBucket` entries survive child deregistration paths that predate `remove_child_node_weight_entries`. On mainnet today: **390 weight entries for a 106-miner fleet** — 284 fossils from every child ever registered. 104 were zeroed operationally via `submit_node_quality` (whitelisted submitter), but **82 are locked**: the pallet rejects quality updates for non-Active children (`ChildNotActive`/`ChildNotRegistered`), `claim_unbonded(Some(child))` is BadOrigin for the submitter, and deregistration demonstrably does not clean weights (25 already-deregistered children still hold non-zero weights).

## Change

New extrinsic `Arion.prune_stale_node_weights(min_stale_buckets, max_children)`:

- **Origin: `WeightAuthorityOrigin` only** (the whitelisted chain-submitter — same origin as `submit_node_quality`; weight state is authority-owned, so is its cleanup).
- Prunes the per-child weight trio only when **both** hold: `NodeWeightLastBucket` older than `min_stale_buckets` (floor 2 — live children are refreshed every bucket by the submitter, so never eligible) **and** no `Active` registration.
- Sweeps `FamilyFirstSeenBucket`/`FamilyWeightRaw`/`FamilyWeight` of affected families with no active children left; deliberately does **not** touch `FamilyCount`/`FamilyUsedFreeSlot` (registration-lifecycle state owned by dereg paths).
- Bounded by new constant `MaxNodeWeightPrunePerCall` (mainnet: 200); collect-then-mutate (no removal while iterating); `Pays::No` like sibling prunes.
- New event `StaleNodeWeightsPruned { children_pruned, families_pruned }`, error `InvalidNodeWeightPruneBatch`; `spec_version` 92001 → 92002.

## Verification

- `cargo check -p pallet-arion` and `cargo check -p hippius-mainnet-runtime` pass (only pre-existing warnings).
- **7 integration tests** against the real mainnet runtime in `runtime/mainnet/tests/prune_stale_node_weights.rs` (same style as `miner_payments.rs`), all passing: prunes stale ghosts + expired unbondings, keeps live and stale-but-Active children, missing `NodeWeightLastBucket` = infinitely stale, family sweep only when no active children remain, `max_children` cap across successive calls, BadOrigin for non-authority signers (incl. root), parameter validation.
- Post-upgrade plan: submitter calls `prune_stale_node_weights(4, 100)` once → expect `children_pruned=82`; the ops-side dead-node-reaper CronJob keeps future Active-but-dark miners at weight 0.

