### PR TITLE
feat(arion): aggregate family weight — score bytes not node count, no more saturation

### DIFF
--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -666,13 +666,25 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxFamilyWeight: Get<u16>;
 
-		/// How many top node weights to count per family (anti “just add infinite children”).
+		/// Byte total at (or below) which a family's aggregate score is 0.
+		/// Lower bound of the useful scoring range (e.g. 100 GiB).
 		#[pallet::constant]
-		type FamilyTopN: Get<u32>;
+		type FamilyScoreFloorBytes: Get<u128>;
 
-		/// Decay factor per rank (permille). Example: 800 → each next node contributes 0.8x the previous.
+		/// Byte total at (or above) which a family's aggregate score reaches [`Config::MaxFamilyScore`].
+		/// Upper bound of the useful scoring range (e.g. 1 PiB).
 		#[pallet::constant]
-		type FamilyRankDecayPermille: Get<u32>;
+		type FamilyScoreCeilBytes: Get<u128>;
+
+		/// Maximum achievable family score from the aggregate formula.
+		/// MUST be < `MaxFamilyWeight` so families can never sit at the storage-type ceiling.
+		#[pallet::constant]
+		type MaxFamilyScore: Get<u16>;
+
+		/// A child whose `NodeWeightLastBucket` is older than this many buckets contributes
+		/// nothing to its family's aggregate (live children are refreshed every bucket).
+		#[pallet::constant]
+		type StaleChildBuckets: Get<u32>;
 
 		/// EMA alpha (permille) for smoothing family weight over time.
 		/// Example: 300 → 30% new, 70% previous.
@@ -2130,46 +2142,101 @@ pub mod pallet {
 			v.min(u16::MAX as u128) as u16
 		}
 
-		fn compute_family_weight_from_nodes(family: &T::AccountId) -> u16 {
-			let max_node = T::MaxNodeWeight::get();
-			let max_family = T::MaxFamilyWeight::get();
-			let top_n = T::FamilyTopN::get().max(1) as usize;
-			let decay = T::FamilyRankDecayPermille::get().min(1000);
-
+		/// Compute a family's weight by scoring its AGGREGATE contribution, not by summing
+		/// per-node scores. This makes the result invariant to how an operator splits the
+		/// same data across children: 1 node with 200 TB scores exactly like 200 nodes with
+		/// 1 TB each. Piling on empty/dust children adds nothing (zero bytes → zero effect).
+		///
+		/// Only `Active` children whose quality was refreshed within
+		/// [`Config::StaleChildBuckets`] contribute; dark children decay out naturally.
+		///
+		/// The log2 blend is normalized over the useful range
+		/// [`Config::FamilyScoreFloorBytes`, `Config::FamilyScoreCeilBytes`] and scaled to
+		/// [`Config::MaxFamilyScore`] (< `MaxFamilyWeight`), so the storage-type ceiling is
+		/// unreachable: rankings never collapse into a saturated plateau.
+		fn compute_family_weight_from_nodes(family: &T::AccountId, current_bucket: u32) -> u16 {
 			let children = FamilyChildren::<T>::get(family);
 			if children.is_empty() {
 				return 0;
 			}
 
-			// Collect node weights for this family.
-			let mut ws: sp_std::vec::Vec<u16> = sp_std::vec::Vec::with_capacity(children.len());
+			// Aggregate raw quality over fresh, Active children. u128 saturating adds:
+			// even MaxChildrenPerFamily children reporting u128::MAX cannot overflow/panic.
+			let stale = T::StaleChildBuckets::get();
+			let mut st_total: u128 = 0;
+			let mut bw_total: u128 = 0;
+			// Weighted uptime numerator: sum(uptime_i * bytes_i). Max per term is
+			// 1000 * u128::MAX which saturates safely; realistic values are far below.
+			let mut up_num: u128 = 0;
+			let mut up_plain_sum: u128 = 0;
+			let mut fresh_children: u128 = 0;
+			let mut strikes_total: u32 = 0;
+			let mut integrity_total: u32 = 0;
 			for c in children.iter() {
-				let w = NodeWeightByChild::<T>::get(c).min(max_node);
-				if w > 0 {
-					ws.push(w);
+				let active = matches!(
+					ChildRegistrations::<T>::get(c),
+					Some(reg) if reg.status == ChildStatus::Active
+				);
+				if !active {
+					continue;
 				}
+				let last = NodeWeightLastBucket::<T>::get(c);
+				if current_bucket.saturating_sub(last) > stale {
+					continue;
+				}
+				let Some(q) = NodeQualityByChild::<T>::get(c) else { continue };
+				let up = q.uptime_permille.min(1000) as u128;
+				st_total = st_total.saturating_add(q.shard_data_bytes);
+				bw_total = bw_total.saturating_add(q.bandwidth_bytes);
+				up_num = up_num.saturating_add(up.saturating_mul(q.shard_data_bytes));
+				up_plain_sum = up_plain_sum.saturating_add(up);
+				fresh_children = fresh_children.saturating_add(1);
+				strikes_total = strikes_total.saturating_add(q.strikes);
+				integrity_total = integrity_total.saturating_add(q.integrity_fails);
 			}
-			if ws.is_empty() {
+			if fresh_children == 0 {
 				return 0;
 			}
-			ws.sort_unstable_by(|a, b| b.cmp(a)); // desc
 
-			// Top-N with rank decay: w0 + w1*decay + w2*decay^2 ...
-			let mut factor_permille: u128 = 1000;
-			let mut sum: u128 = 0;
-			for (i, w) in ws.iter().take(top_n).enumerate() {
-				if i == 0 {
-					// factor=1000 for first term
-				} else {
-					factor_permille = factor_permille.saturating_mul(decay as u128) / 1000u128;
-				}
-				let term = (*w as u128).saturating_mul(factor_permille) / 1000u128;
-				sum = sum.saturating_add(term);
-				if sum >= max_family as u128 {
-					return max_family;
-				}
-			}
-			sum.min(max_family as u128) as u16
+			// Uptime of the aggregate: byte-weighted when bytes exist, plain mean otherwise.
+			let uptime = if st_total > 0 {
+				(up_num / st_total).min(1000)
+			} else {
+				(up_plain_sum / fresh_children).min(1000)
+			};
+
+			// Normalize log2 of the aggregates over [floor, ceil]. All fixed-point 8.8
+			// (log2 * 256), so every value fits in u32 and products stay tiny for u128.
+			let lo_fx = Self::log2_fixed_u128(T::FamilyScoreFloorBytes::get().max(1)) as u128;
+			let hi_fx = Self::log2_fixed_u128(T::FamilyScoreCeilBytes::get().max(2)) as u128;
+			let den_fx = hi_fx.saturating_sub(lo_fx).max(1);
+			let component = |bytes: u128| -> u128 {
+				let v = Self::log2_fixed_u128(bytes.saturating_add(1)) as u128;
+				v.saturating_sub(lo_fx).min(den_fx)
+			};
+			let bw_w = T::NodeBandwidthWeightPermille::get().min(1000) as u128;
+			let st_w = T::NodeStorageWeightPermille::get().min(1000) as u128;
+			let denom_w = (bw_w + st_w).max(1);
+			// Max blend = den_fx * 1000; den_fx <= 127*256+255 (~32.7k) → max ~32.7M, fits u128.
+			let blend = component(bw_total)
+				.saturating_mul(bw_w)
+				.saturating_add(component(st_total).saturating_mul(st_w))
+				/ denom_w;
+
+			// Scale to MaxFamilyScore. Max product = 32.7k * 60_000 (~2e9) — fits u128.
+			let max_score = T::MaxFamilyScore::get().min(T::MaxFamilyWeight::get()) as u128;
+			let base = blend.saturating_mul(max_score) / den_fx;
+
+			// Uptime multiplier, then penalties (same constants as per-node scoring).
+			let with_uptime = base.saturating_mul(uptime) / 1000u128;
+			let pen = (strikes_total as u128)
+				.saturating_mul(T::StrikePenalty::get() as u128)
+				.saturating_add(
+					(integrity_total as u128)
+						.saturating_mul(T::IntegrityFailPenalty::get() as u128),
+				);
+			let final_score = with_uptime.saturating_sub(pen).min(max_score);
+			final_score as u16
 		}
 
 		pub fn get_total_family_weight() -> u128 {
@@ -2291,7 +2358,7 @@ pub mod pallet {
 
 			let mut computed: u32 = 0;
 			for family in families_to_recompute.iter() {
-				let raw = Self::compute_family_weight_from_nodes(family);
+				let raw = Self::compute_family_weight_from_nodes(family, bucket);
 
 				// Newcomer floor, only if raw > 0 and within grace
 				let raw = if raw > 0 {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -229,8 +229,10 @@ impl pallet_arion::Config for Runtime {
 	type MaxNodeWeightUpdates = MaxNodeWeightUpdates;
 	type MaxNodeWeight = MaxNodeWeight;
 	type MaxFamilyWeight = MaxFamilyWeight;
-	type FamilyTopN = FamilyTopN;
-	type FamilyRankDecayPermille = FamilyRankDecayPermille;
+	type FamilyScoreFloorBytes = FamilyScoreFloorBytes;
+	type FamilyScoreCeilBytes = FamilyScoreCeilBytes;
+	type MaxFamilyScore = MaxFamilyScore;
+	type StaleChildBuckets = StaleChildBuckets;
 	type FamilyWeightEmaAlphaPermille = FamilyWeightEmaAlphaPermille;
 	type MaxFamilyWeightDeltaPerBucket = MaxFamilyWeightDeltaPerBucket;
 	type NewcomerGraceBuckets = NewcomerGraceBuckets;
@@ -354,7 +356,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92001,
+	spec_version: 92002,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`
@@ -397,10 +399,14 @@ parameter_types! {
 	pub const MaxNodeWeight: u16 = 50_000;
 	// Maximum family weight
 	pub const MaxFamilyWeight: u16 = 65_535;
-	// Number of top nodes to consider per family
-	pub const FamilyTopN: u32 = 10;
-	// Decay factor for family rank (permille)
-	pub const FamilyRankDecayPermille: u32 = 800;
+	// Aggregate family scoring range: 0 at 100 GiB, MaxFamilyScore at 1 PiB
+	pub const FamilyScoreFloorBytes: u128 = 100 * (1u128 << 30);
+	pub const FamilyScoreCeilBytes: u128 = 1u128 << 50;
+	// Max achievable family score — strictly below MaxFamilyWeight (u16::MAX)
+	// so families can never sit saturated at the storage-type ceiling.
+	pub const MaxFamilyScore: u16 = 60_000;
+	// Children not refreshed for more than this many buckets stop counting.
+	pub const StaleChildBuckets: u32 = 4;
 	// EMA alpha for family weight (permille)
 	pub const FamilyWeightEmaAlphaPermille: u32 = 300;
 	// Maximum family weight delta per bucket

--- a/runtime/mainnet/tests/family_weight_aggregate.rs
+++ b/runtime/mainnet/tests/family_weight_aggregate.rs
@@ -1,0 +1,280 @@
+//! Tests for the aggregate family weight formula.
+//!
+//! The family score is computed from the AGGREGATE bytes of its fresh Active
+//! children (not a sum of per-node scores), normalized over the useful range
+//! [FamilyScoreFloorBytes, FamilyScoreCeilBytes] and capped at MaxFamilyScore
+//! (< MaxFamilyWeight). Assertions read `FamilyWeightRaw` — the raw computed
+//! value — because `FamilyWeight` is EMA-smoothed and delta-clamped.
+
+use frame_support::assert_ok;
+use hippius_mainnet_runtime::{AccountId, Arion, Runtime, RuntimeOrigin, System};
+use pallet_arion::{
+	ChildRegistration, ChildRegistrations, ChildStatus, CurrentWeightBucket, FamilyActiveChildren,
+	FamilyChildren, FamilyWeightRaw, NodeQuality, NodeQualityByChild, NodeWeightLastBucket,
+};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{AccountId32, BuildStorage};
+
+const BUCKET: u32 = 100;
+const TIB: u128 = 1024 * 1024 * 1024 * 1024;
+
+/// Whitelisted `ArionAdminMembers` account (WeightAuthorityOrigin).
+fn admin() -> AccountId {
+	AccountId32::from_ss58check("5CVXqxb7mhFTtZVw5BJ8M2ujND9PFymSDxF8bkod6Sm4XJTW").unwrap()
+}
+
+fn account(seed: u8, tag: u8) -> AccountId {
+	let mut raw = [seed; 32];
+	raw[0] = tag;
+	AccountId32::new(raw)
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		CurrentWeightBucket::<Runtime>::put(BUCKET);
+	});
+	ext
+}
+
+fn quality(bytes: u128, bw: u128, uptime: u16) -> NodeQuality {
+	NodeQuality {
+		shard_data_bytes: bytes,
+		bandwidth_bytes: bw,
+		uptime_permille: uptime,
+		strikes: 0,
+		integrity_fails: 0,
+	}
+}
+
+/// Register a child under a family and add it to the family index.
+fn add_child(family: &AccountId, child: &AccountId) {
+	let node_id: [u8; 32] = child.clone().into();
+	ChildRegistrations::<Runtime>::insert(
+		child,
+		ChildRegistration {
+			family: family.clone(),
+			node_id,
+			status: ChildStatus::Active,
+			deposit: 0u128,
+			unbonding_end: 0u32.into(),
+		},
+	);
+	FamilyChildren::<Runtime>::mutate(family, |v| {
+		v.try_push(child.clone()).expect("under MaxChildrenPerFamily");
+	});
+	FamilyActiveChildren::<Runtime>::mutate(family, |n| *n += 1);
+}
+
+/// Submit quality for the given (child, quality) pairs and trigger the recompute.
+fn submit(pairs: Vec<(AccountId, NodeQuality)>) {
+	let updates: Vec<(AccountId, NodeQuality)> = pairs;
+	assert_ok!(Arion::submit_node_quality(
+		RuntimeOrigin::signed(admin()),
+		BUCKET,
+		updates.try_into().expect("under MaxNodeWeightUpdates"),
+	));
+}
+
+fn raw(family: &AccountId) -> u16 {
+	FamilyWeightRaw::<Runtime>::get(family)
+}
+
+#[test]
+fn fragmentation_is_neutral() {
+	new_test_ext().execute_with(|| {
+		// Family A: one node with 4 TiB. Family B: four nodes with 1 TiB each.
+		let fam_a = account(1, 0);
+		let fam_b = account(2, 0);
+		let a1 = account(1, 10);
+		add_child(&fam_a, &a1);
+		let mut pairs = vec![(a1, quality(4 * TIB, 0, 900))];
+		for i in 0..4u8 {
+			let c = account(2, 10 + i);
+			add_child(&fam_b, &c);
+			pairs.push((c, quality(TIB, 0, 900)));
+		}
+		submit(pairs);
+
+		assert_eq!(raw(&fam_a), raw(&fam_b), "same total bytes must score identically");
+		assert!(raw(&fam_a) > 0);
+	});
+}
+
+#[test]
+fn strictly_monotonic_in_bytes() {
+	new_test_ext().execute_with(|| {
+		let sizes = [TIB, 10 * TIB, 100 * TIB];
+		let mut pairs = Vec::new();
+		let mut fams = Vec::new();
+		for (i, sz) in sizes.iter().enumerate() {
+			let fam = account(10 + i as u8, 0);
+			let c = account(10 + i as u8, 1);
+			add_child(&fam, &c);
+			pairs.push((c, quality(*sz, 0, 1000)));
+			fams.push(fam);
+		}
+		submit(pairs);
+
+		let (w1, w10, w100) = (raw(&fams[0]), raw(&fams[1]), raw(&fams[2]));
+		assert!(w1 < w10 && w10 < w100, "ranking must exist: {w1} < {w10} < {w100}");
+	});
+}
+
+#[test]
+fn never_reaches_the_type_ceiling() {
+	new_test_ext().execute_with(|| {
+		// 10 children of 100 TiB (~1 PiB aggregate = the calibration ceiling),
+		// maximum bandwidth, perfect uptime.
+		let fam = account(20, 0);
+		let mut pairs = Vec::new();
+		for i in 0..10u8 {
+			let c = account(20, 10 + i);
+			add_child(&fam, &c);
+			pairs.push((c, quality(100 * TIB, 100 * TIB, 1000)));
+		}
+		submit(pairs);
+
+		let w = raw(&fam);
+		let max_score = 60_000u16; // runtime MaxFamilyScore
+		assert!(w <= max_score, "raw {w} must not exceed MaxFamilyScore");
+		assert!(w < u16::MAX, "families must never sit at the u16 ceiling");
+		assert!(w > 50_000, "a ceiling-range family should still score near the top: {w}");
+	});
+}
+
+#[test]
+fn absurd_inputs_do_not_overflow() {
+	new_test_ext().execute_with(|| {
+		// u128::MAX everywhere: must not panic, must stay bounded.
+		let fam = account(30, 0);
+		let mut pairs = Vec::new();
+		for i in 0..3u8 {
+			let c = account(30, 10 + i);
+			add_child(&fam, &c);
+			pairs.push((
+				c,
+				NodeQuality {
+					shard_data_bytes: u128::MAX,
+					bandwidth_bytes: u128::MAX,
+					uptime_permille: u16::MAX, // > 1000, must be clamped
+					strikes: 0,
+					integrity_fails: 0,
+				},
+			));
+		}
+		submit(pairs);
+		assert!(raw(&fam) <= 60_000);
+
+		// Max penalties: must saturate to zero, not underflow.
+		let fam2 = account(31, 0);
+		let c2 = account(31, 10);
+		add_child(&fam2, &c2);
+		submit(vec![(
+			c2,
+			NodeQuality {
+				shard_data_bytes: 10 * TIB,
+				bandwidth_bytes: 0,
+				uptime_permille: 1000,
+				strikes: u32::MAX,
+				integrity_fails: u32::MAX,
+			},
+		)]);
+		assert_eq!(raw(&fam2), 0);
+	});
+}
+
+#[test]
+fn dust_children_add_nothing() {
+	new_test_ext().execute_with(|| {
+		let fam_solo = account(40, 0);
+		let solo = account(40, 10);
+		add_child(&fam_solo, &solo);
+		let mut pairs = vec![(solo, quality(10 * TIB, 0, 900))];
+
+		// Same bytes plus 30 dust children of 1 byte each.
+		let fam_dust = account(41, 0);
+		let big = account(41, 10);
+		add_child(&fam_dust, &big);
+		pairs.push((big, quality(10 * TIB, 0, 900)));
+		for i in 0..30u8 {
+			let c = account(41, 50 + i);
+			add_child(&fam_dust, &c);
+			pairs.push((c, quality(1, 0, 900)));
+		}
+		submit(pairs);
+
+		let diff = raw(&fam_dust).abs_diff(raw(&fam_solo));
+		assert!(diff <= 1, "30 dust children changed the score by {diff}");
+	});
+}
+
+#[test]
+fn stale_children_stop_counting() {
+	new_test_ext().execute_with(|| {
+		// Family with one fresh and one stale child of equal size: the stale one
+		// must contribute nothing, so the family scores like the fresh child alone.
+		let fam = account(50, 0);
+		let fresh = account(50, 10);
+		let stale = account(50, 11);
+		add_child(&fam, &fresh);
+		add_child(&fam, &stale);
+		// Stale child: quality present but last refreshed 10 buckets ago (> StaleChildBuckets=4).
+		NodeQualityByChild::<Runtime>::insert(&stale, quality(10 * TIB, 0, 1000));
+		NodeWeightLastBucket::<Runtime>::insert(&stale, BUCKET - 10);
+
+		let fam_ref = account(51, 0);
+		let only = account(51, 10);
+		add_child(&fam_ref, &only);
+
+		submit(vec![
+			(fresh, quality(10 * TIB, 0, 1000)),
+			(only, quality(10 * TIB, 0, 1000)),
+		]);
+
+		assert_eq!(raw(&fam), raw(&fam_ref), "stale child must contribute zero");
+
+		// Family whose ONLY child went stale: raw collapses to 0.
+		let fam_dead = account(52, 0);
+		let dead = account(52, 10);
+		add_child(&fam_dead, &dead);
+		NodeQualityByChild::<Runtime>::insert(&dead, quality(10 * TIB, 0, 1000));
+		NodeWeightLastBucket::<Runtime>::insert(&dead, BUCKET - 10);
+		// Trigger a recompute via an unrelated submission.
+		submit(vec![(account(51, 10), quality(10 * TIB, 0, 1000))]);
+		assert_eq!(raw(&fam_dead), 0);
+	});
+}
+
+#[test]
+fn uptime_scales_the_score() {
+	new_test_ext().execute_with(|| {
+		let fam_hi = account(60, 0);
+		let hi = account(60, 10);
+		add_child(&fam_hi, &hi);
+		let fam_lo = account(61, 0);
+		let lo = account(61, 10);
+		add_child(&fam_lo, &lo);
+		submit(vec![
+			(hi, quality(10 * TIB, 0, 1000)),
+			(lo, quality(10 * TIB, 0, 500)),
+		]);
+		let (whi, wlo) = (raw(&fam_hi) as u32, raw(&fam_lo) as u32);
+		assert!(wlo * 2 >= whi.saturating_sub(2) && wlo * 2 <= whi + 2,
+			"uptime 500 should halve the score: hi={whi} lo={wlo}");
+	});
+}
+
+#[test]
+fn below_floor_scores_zero() {
+	new_test_ext().execute_with(|| {
+		// 10 GiB total is below the 100 GiB floor: no score.
+		let fam = account(70, 0);
+		let c = account(70, 10);
+		add_child(&fam, &c);
+		submit(vec![(c, quality(10 * 1024 * 1024 * 1024, 0, 1000))]);
+		assert_eq!(raw(&fam), 0);
+	});
+}


### PR DESCRIPTION
## Problem

Family weight = top-10 per-node scores summed with 0.8 rank decay, capped at `MaxFamilyWeight = u16::MAX`. Two structural defects, both observed on mainnet:

1. **Saturation**: node scores sit at 46-50k (log-compressed), so any family with ~1.3 maxed nodes pins at 65_535. Real case: family `5FprzN31…` has 2 children (49_071 + 48_485) → raw 65_535, indistinguishable from a 10-node family. Ranking between large families does not exist.
2. **Fragmentation pays**: summing per-node scores rewards splitting the same data across more children (up to 4.46x), while CRUSH placement selects only ONE node per family per stripe — extra children attract zero additional shards per stripe. Free weight for identical service.

## Change

`compute_family_weight_from_nodes` now scores the family's **aggregate**: sum of `shard_data_bytes` / `bandwidth_bytes` over fresh Active children, byte-weighted uptime, summed penalties — pushed through a log2 blend normalized over a calibrated useful range.

- **Fragmentation-neutral**: 1×200 TB == 200×1 TB, exactly. Dust children add nothing.
- **No saturation, ever**: normalized over [100 GiB → 1 PiB] and scaled to `MaxFamilyScore = 60_000 < u16::MAX`. Rankings stay strict across the whole realistic range (1 TiB < 10 TiB < 100 TiB tested).
- **Stale decay**: children not refreshed within `StaleChildBuckets = 4` stop counting — dark families decay instead of freezing (root cause of the fossil-weight issue).
- **Overflow-safe**: u128 saturating arithmetic throughout; log2 fixed-point ≤ 32_767 keeps all products ~15 orders of magnitude below u128::MAX. Adversarial test feeds `u128::MAX` bytes + `u32::MAX` strikes: bounded, no panic.
- Seniority gating (earned-capacity ramp) intentionally stays **off-chain in the validator** — the chain only keeps defensive bounds.

Config: removes `FamilyTopN` / `FamilyRankDecayPermille`; adds `FamilyScoreFloorBytes`, `FamilyScoreCeilBytes`, `MaxFamilyScore`, `StaleChildBuckets`. `spec_version` 92001 → 92002 (note: PR #44 also bumps to 92002 — whichever merges second should rebase to 92003).

## Verification

- 8 new integration tests (`runtime/mainnet/tests/family_weight_aggregate.rs`): fragmentation neutrality, strict monotonicity, ceiling unreachable, u128::MAX overflow safety, dust immunity, stale exclusion, uptime scaling, floor cutoff.
- All pre-existing suites still pass (110 tests: miner_payments, adversarial, referral, …).
- EMA smoothing + `MaxFamilyWeightDeltaPerBucket` clamp unchanged: on-chain weights converge to the new scale at ≤100/bucket, no step change at upgrade.