### PR TITLE
feat(marketplace): atomic change_storage_plan for whitelisted callers

### DIFF
--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -522,6 +522,19 @@ pub mod pallet {
 		WhitelistedCallerRemoved {
 			account: T::AccountId,
 		},
+		/// A user's active storage subscription was moved onto a different plan
+		/// by a whitelisted caller, in one dispatch.
+		///
+		/// `charged_credits` and `refunded_credits` are the two halves of a single
+		/// net credit movement, so at most one of them is ever non-zero.
+		StoragePlanChanged {
+			user: T::AccountId,
+			old_plan: T::Hash,
+			new_plan: T::Hash,
+			subscription_id: SubscriptionId,
+			charged_credits: u128,
+			refunded_credits: u128,
+		},
 	}
 
 	#[pallet::error]
@@ -1080,6 +1093,65 @@ pub mod pallet {
 				Some(id) => Self::do_cancel_subscription_by_id(&user, id),
 				None => Self::do_delete_storage_subscription_with_refund(&user),
 			}
+		}
+
+		/// Move a user's active storage subscription onto a different storage plan
+		/// — upgrade or downgrade — in one dispatch (restricted to whitelisted
+		/// callers, same ACL as `purchase_plan` / `cancel_user_subscription`).
+		///
+		/// This exists because cancel + re-purchase is not a plan change:
+		/// - it opens a window in which the user holds no storage entitlement,
+		/// - the re-purchase re-checks the `MinSubscriptionBlocks` resubscribe
+		///   cooldown against `LastSubscriptionCancelledAt`, forcing the caller to
+		///   sequence the two calls across blocks and retry on
+		///   `ResubscribeCooldownActive`,
+		/// - and it splits the refund and the new charge into two credit movements,
+		///   which double-charges the month the user has already paid for.
+		///
+		/// So this call never sets `LastSubscriptionCancelledAt` (a change is not a
+		/// cancellation), never lets the subscription slot go empty, and settles the
+		/// whole swap as a single net credit movement. Referral attribution
+		/// (`ReferredUsers`) is left exactly as it was; the buyer discount and the
+		/// referrer commission apply to the new plan as they do at purchase.
+		///
+		/// `selected_image_name` / `location_id` / `cloud_init_cid` mirror
+		/// `purchase_plan`'s per-plan inputs so the backend can pass the same shape
+		/// on both calls. Storage plans are provisioned from the plan alone, so —
+		/// exactly as in `purchase_plan`'s `is_storage_plan` branch — they are
+		/// accepted and not written to the subscription.
+		#[pallet::call_index(30)]
+		#[pallet::weight((0, Pays::No))]
+		pub fn change_storage_plan(
+			origin: OriginFor<T>,
+			user: T::AccountId,
+			new_plan_id: T::Hash,
+			selected_image_name: Option<Vec<u8>>,
+			location_id: Option<u32>,
+			cloud_init_cid: Option<Vec<u8>>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let allowed = WhitelistedCallers::<T>::get();
+			ensure!(allowed.contains(&who), Error::<T>::WhitelistedCallerNotAuthorized);
+
+			// Same per-block rate limit `purchase_plan` applies, counted against the
+			// subscriber rather than the relayer — it is what bounds repeated plan
+			// changes within a block, since this call has no resubscribe cooldown.
+			let max_requests_per_block = T::MaxRequestsPerBlock::get();
+			let user_requests_count = UserRequestsCount::<T>::get(&user);
+			ensure!(
+				user_requests_count.saturating_add(1) <= max_requests_per_block,
+				Error::<T>::TooManyRequests
+			);
+			UserRequestsCount::<T>::insert(&user, user_requests_count.saturating_add(1));
+
+			Self::do_change_storage_plan(
+				&user,
+				new_plan_id,
+				location_id,
+				Self::normalize_image_selection(selected_image_name),
+				cloud_init_cid,
+			)
 		}
 
 		/// Update the total Drive + S3 file size/count for a user.
@@ -1664,6 +1736,164 @@ pub mod pallet {
 
 			// Save the updated subscriptions list
 			UserAllSubscriptionPlans::<T>::insert(&who, subscriptions);
+
+			Ok(())
+		}
+
+		/// Swap `account_id`'s single active storage subscription onto `new_plan_id`.
+		///
+		/// Money model — one net movement, never two:
+		/// - `refund_credits`: unused prepaid *full* months on the old plan, i.e.
+		///   exactly what the cancel path refunds (`unused_prepaid_refund_credits`).
+		/// - `carry_credits`: what the unexpired remainder of the **current** month
+		///   is worth on the old plan. The cancel path deliberately never refunds
+		///   the current month, and neither do we — this is only applied as a credit
+		///   *against* the new plan's first month, so an upgrade pays the difference
+		///   instead of paying for the same month twice. Paying it out on a
+		///   downgrade would mint credits carrying no alpha backing on a call that
+		///   has no resubscribe cooldown, i.e. a free plan-cycling loop; capping it
+		///   at the new charge closes that while still fixing the double-charge.
+		/// - The new plan's first month is prorated and discounted exactly as a
+		///   fresh purchase would be, and `next_charge_unix_day` lands on the 1st of
+		///   next month, so recurring charging treats it like any other new
+		///   subscription.
+		///
+		/// The refund is then netted against the charge, so `FreeCredits` moves once
+		/// and prepaid months can pay for the new plan directly.
+		fn do_change_storage_plan(
+			account_id: &T::AccountId,
+			new_plan_id: T::Hash,
+			_location_id: Option<u32>,
+			_selected_image_name: Option<Vec<u8>>,
+			_cloud_init_cid: Option<Vec<u8>>,
+		) -> DispatchResult {
+			ensure!(
+				!RegistrationPallet::<T>::is_node_type_disabled(NodeType::StorageMiner),
+				Error::<T>::NodeTypeDisabled
+			);
+
+			// Same kill switch `purchase_plan` honours: if new storage plans cannot
+			// be bought, they cannot be switched into either.
+			ensure!(Self::is_purchase_plan_enabled(), Error::<T>::PlanOperationDisabled);
+
+			let mut subscriptions = UserAllSubscriptionPlans::<T>::get(account_id);
+
+			// Exactly one active storage subscription. `do_purchase_storage_plan`
+			// enforces that invariant on the way in, so more than one is corrupt
+			// state we refuse rather than silently pick a winner from.
+			let mut active_storage = subscriptions
+				.iter()
+				.enumerate()
+				.filter(|(_, s)| s.active && s.package.is_storage_plan)
+				.map(|(i, _)| i);
+			let index = active_storage.next().ok_or(Error::<T>::NoActiveSubscription)?;
+			ensure!(active_storage.next().is_none(), Error::<T>::TooManyActiveSubscriptions);
+
+			let old_sub = subscriptions[index].clone();
+			let old_plan_id = old_sub.package.id;
+			ensure!(new_plan_id != old_plan_id, Error::<T>::InvalidInput);
+
+			let new_plan = Plans::<T>::get(&new_plan_id).ok_or(Error::<T>::PlanNotFound)?;
+			ensure!(!new_plan.is_suspended, Error::<T>::PlanSuspended);
+			ensure!(new_plan.is_storage_plan, Error::<T>::InvalidPlanType);
+
+			// Unused prepaid full months on the old plan — the cancel refund, unchanged.
+			let refund_credits = Self::unused_prepaid_refund_credits(&old_sub);
+
+			// Value of the remaining days of the current month on the old plan. Only
+			// counts while the old subscription is actually paid through the current
+			// month; a lapsed subscription, or a legacy one with no
+			// `next_charge_unix_day`, carries nothing forward. `paid_per_month` is
+			// the discounted price actually billed, so the carry never exceeds what
+			// the user paid for those days.
+			let paid_through_this_month = old_sub
+				.next_charge_unix_day
+				.is_some_and(|due_day| due_day > Self::current_unix_day());
+			let carry_credits = if paid_through_this_month {
+				Self::prorated_monthly_price(old_sub.paid_per_month)
+			} else {
+				0
+			};
+
+			// New plan's first month, prorated and discounted like a fresh purchase.
+			let new_plan_price = Self::prorated_monthly_price(new_plan.price);
+			let (referral_discount, ref_owner) =
+				Self::referral_discount_and_owner(account_id, new_plan_price);
+			let charged_credits =
+				new_plan_price.saturating_sub(referral_discount).saturating_sub(carry_credits);
+
+			// Net the two halves so `FreeCredits` moves exactly once, and check
+			// affordability against that net delta before touching any state.
+			let net_charge = charged_credits.saturating_sub(refund_credits);
+			let net_refund = refund_credits.saturating_sub(charged_credits);
+
+			let user_free_credits = CreditsPallet::<T>::get_free_credits(account_id);
+			ensure!(user_free_credits >= net_charge, Error::<T>::InsufficientFreeCredits);
+
+			if net_charge > 0 {
+				Self::consume_credits(account_id.clone(), net_charge)?;
+				Self::record_credits_transaction(
+					account_id,
+					NativeTransactionType::Subscription,
+					net_charge,
+				)?;
+			}
+
+			if net_refund > 0 {
+				// Mints the refund and records the `Refund` transaction itself.
+				Self::refund_credits_with_batch(account_id, net_refund)?;
+			}
+
+			// Commission on the credits actually collected by this call. The
+			// refunded months already paid a commission when they were bought, so
+			// netting first is what stops a plan change from paying twice on them.
+			if let Some(owner) = ref_owner {
+				let commission = Self::referral_commission_credits(net_charge);
+				Self::try_pay_referral_commission_tokens(&owner, commission);
+			}
+
+			let subscription_id = NextSubscriptionId::<T>::mutate(|id| {
+				let current_id = *id;
+				*id = id.saturating_add(1);
+				current_id
+			});
+
+			// 95% of face price for referred users — the same conserved split the
+			// purchase paths record, so future refunds keep valuing a month correctly.
+			let paid_per_month = if CreditsPallet::<T>::referred_users(account_id).is_some() {
+				split(Credits::new(new_plan.price), BasisPoints::new(9_500)).0.get()
+			} else {
+				new_plan.price
+			};
+
+			// Replace in place. The slot stays occupied for the whole dispatch, so
+			// the storage entitlement never lapses and the change can never trip
+			// `MaxActiveSubscriptions` the way a re-purchase could.
+			subscriptions[index] = UserPlanSubscription {
+				id: subscription_id,
+				owner: account_id.clone(),
+				package: new_plan,
+				cdn_location_id: None,
+				active: true,
+				last_charged_at: <frame_system::Pallet<T>>::block_number(),
+				selected_image_name: None,
+				next_charge_unix_day: Some(
+					pallet_calendar::Pallet::<T>::unix_day_of_first_of_month_in(1),
+				),
+				paid_per_month,
+				_phantom: PhantomData,
+			};
+
+			UserAllSubscriptionPlans::<T>::insert(account_id, subscriptions);
+
+			Self::deposit_event(Event::StoragePlanChanged {
+				user: account_id.clone(),
+				old_plan: old_plan_id,
+				new_plan: new_plan_id,
+				subscription_id,
+				charged_credits: net_charge,
+				refunded_credits: net_refund,
+			});
 
 			Ok(())
 		}

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -369,7 +369,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92002,
+	spec_version: 92003,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`
@@ -1914,6 +1914,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					// NonTransfer proxies must not be able to drain the principal via
 					// credit purchases or hAlpha withdrawals.
 					| RuntimeCall::Marketplace(pallet_marketplace::Call::purchase_plan { .. })
+					// A plan upgrade consumes credits for the net delta, same drain.
+					| RuntimeCall::Marketplace(
+						pallet_marketplace::Call::change_storage_plan { .. }
+					)
 					| RuntimeCall::AlphaBridge(pallet_alpha_bridge::Call::withdraw { .. })
 			),
 			ProxyType::Governance => matches!(

--- a/runtime/mainnet/tests/change_storage_plan.rs
+++ b/runtime/mainnet/tests/change_storage_plan.rs
@@ -1,0 +1,496 @@
+//! End-to-end behaviour of `Marketplace::change_storage_plan` — the atomic
+//! Solo → Duo → Max swap the backend relayer drives on a user's behalf.
+//!
+//! The property under test is that a plan change is *not* a cancel plus a
+//! re-purchase:
+//! - the storage entitlement never lapses (the subscription slot is replaced
+//!   in place, never emptied),
+//! - `LastSubscriptionCancelledAt` is never written, so the
+//!   `MinSubscriptionBlocks` resubscribe cooldown is never armed and the two
+//!   calls never have to be sequenced across blocks,
+//! - and the refund for the old plan and the charge for the new one collapse
+//!   into a single net `FreeCredits` movement, so the month the user already
+//!   paid for is not billed twice.
+//!
+//! All expected credit amounts below are hand-computed from the ceil-rounded
+//! `prorate_first_month` so a regression in the proration wiring fails loudly
+//! instead of cancelling out against a re-derived expectation.
+
+use frame_support::{
+	assert_err, assert_noop, assert_ok,
+	traits::{Currency, Hooks},
+};
+use hippius_mainnet_runtime::{
+	AccountId, Balances, Credits, Hippocampus, Marketplace, Runtime, RuntimeCall, RuntimeOrigin,
+	System,
+};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{
+	traits::{Dispatchable, Hash},
+	AccountId32, BuildStorage,
+};
+
+type Hashed = <Runtime as frame_system::Config>::Hash;
+
+/// 2026-01-01T00:00:00Z. January has 31 days, so a purchase on the 1st
+/// prorates to exactly one full month — the arithmetic-free baseline.
+const JAN1_2026_MS: u64 = 1_767_225_600_000;
+/// 2026-01-16T12:00:00Z — 16 of 31 days remain (inclusive of today), the
+/// mid-month case where proration actually rounds.
+const JAN16_2026_MS: u64 = JAN1_2026_MS + 15 * 86_400_000 + 12 * 3_600_000;
+
+const FEB1_2026_DAY: u32 = 20_485;
+const APR1_2026_DAY: u32 = 20_544;
+
+/// Plan ladder. Prices are round so the netting assertions read directly.
+const SOLO_PRICE: u128 = 1_000;
+const MAX_PRICE: u128 = 3_000;
+
+/// Mid-month (16/31) prorations, ceil-rounded: ⌈1_000×16/31⌉ = 517,
+/// ⌈3_000×16/31⌉ = 1_549.
+const SOLO_PRORATED: u128 = 517;
+const MAX_PRORATED: u128 = 1_549;
+
+const ED: u128 = 500;
+const BANK_FUND: u128 = 1_000_000;
+
+fn account(seed: u8) -> AccountId {
+	AccountId32::new([seed; 32])
+}
+
+fn authority() -> AccountId {
+	account(1)
+}
+
+/// Backend account whitelisted for `purchase_plan` / `change_storage_plan`.
+fn backend() -> AccountId {
+	account(2)
+}
+
+fn admin() -> AccountId {
+	AccountId32::from_ss58check("5CVXqxb7mhFTtZVw5BJ8M2ujND9PFymSDxF8bkod6Sm4XJTW").unwrap()
+}
+
+fn new_test_ext_at(now_ms: u64) -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		pallet_timestamp::Now::<Runtime>::put(now_ms);
+		assert_ok!(Credits::add_authority(RuntimeOrigin::root(), authority()));
+		assert_ok!(Marketplace::sudo_set_whitelist_canceller(RuntimeOrigin::root(), backend()));
+		assert_ok!(Marketplace::sudo_set_purchase_plan_enabled(RuntimeOrigin::root(), true));
+		let _ = Balances::deposit_creating(&Hippocampus::account_id(), BANK_FUND);
+		assert_ok!(Hippocampus::add_requester(
+			RuntimeOrigin::signed(admin()),
+			Marketplace::account_id(),
+		));
+	});
+	ext
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	new_test_ext_at(JAN1_2026_MS)
+}
+
+fn add_plan(name: &[u8], price: u128, is_storage_plan: bool) -> Hashed {
+	assert_ok!(Marketplace::add_new_plan(
+		RuntimeOrigin::root(),
+		name.to_vec(),
+		b"{}".to_vec(),
+		b"{}".to_vec(),
+		price,
+		is_storage_plan,
+		Some(price * 1_000),
+	));
+	<Runtime as frame_system::Config>::Hashing::hash_of(&name.to_vec())
+}
+
+/// The Solo/Max storage ladder used by most tests.
+fn ladder() -> (Hashed, Hashed) {
+	(add_plan(b"solo", SOLO_PRICE, true), add_plan(b"max", MAX_PRICE, true))
+}
+
+fn deposit_credits(who: &AccountId, amount: u128, code: Option<Vec<u8>>) {
+	assert_ok!(Marketplace::deposit(
+		RuntimeOrigin::signed(authority()),
+		who.clone(),
+		amount,
+		0,
+		false,
+		code,
+	));
+}
+
+fn purchase(owner: &AccountId, plan_id: Hashed, pay_upfront: Option<u128>) {
+	assert_ok!(Marketplace::purchase_plan(
+		RuntimeOrigin::signed(backend()),
+		owner.clone(),
+		vec![plan_id],
+		None,
+		None,
+		None,
+		pay_upfront,
+	));
+}
+
+fn change_plan(user: &AccountId, new_plan_id: Hashed) -> frame_support::dispatch::DispatchResult {
+	Marketplace::change_storage_plan(
+		RuntimeOrigin::signed(backend()),
+		user.clone(),
+		new_plan_id,
+		None,
+		None,
+		None,
+	)
+}
+
+/// Same change dispatched through `RuntimeCall` so extrinsic-level rollback
+/// applies — required for the atomicity assertions on failure paths.
+fn dispatch_change(
+	user: &AccountId,
+	new_plan_id: Hashed,
+) -> frame_support::dispatch::DispatchResultWithPostInfo {
+	RuntimeCall::Marketplace(pallet_marketplace::Call::change_storage_plan {
+		user: user.clone(),
+		new_plan_id,
+		selected_image_name: None,
+		location_id: None,
+		cloud_init_cid: None,
+	})
+	.dispatch(RuntimeOrigin::signed(backend()))
+}
+
+fn storage_subscription(owner: &AccountId) -> pallet_marketplace::UserPlanSubscription<Runtime> {
+	Marketplace::user_all_subscription_plans(owner)
+		.into_iter()
+		.find(|s| s.package.is_storage_plan)
+		.expect("storage subscription exists")
+}
+
+fn new_referral_code(owner: &AccountId) -> Vec<u8> {
+	assert_ok!(Credits::create_referral_code(RuntimeOrigin::signed(owner.clone())));
+	Credits::get_referral_codes(owner.clone()).pop().expect("code was just created")
+}
+
+// ── Upgrades ─────────────────────────────────────────────────────────────
+
+#[test]
+fn upgrade_on_the_first_charges_only_the_price_difference() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		// Enough for Solo plus the upgrade delta, and not a credit more —
+		// paying for January twice would not fit.
+		deposit_credits(&user, SOLO_PRICE + (MAX_PRICE - SOLO_PRICE), None);
+		purchase(&user, solo, None);
+		assert_eq!(Credits::get_free_credits(&user), MAX_PRICE - SOLO_PRICE);
+
+		assert_ok!(change_plan(&user, max));
+
+		assert_eq!(Credits::get_free_credits(&user), 0, "only the delta is charged");
+		let sub = storage_subscription(&user);
+		assert_eq!(sub.package.id, max);
+		assert_eq!(sub.paid_per_month, MAX_PRICE);
+		assert_eq!(sub.next_charge_unix_day, Some(FEB1_2026_DAY));
+		assert!(sub.active);
+	});
+}
+
+#[test]
+fn mid_month_upgrade_never_bills_the_remaining_days_twice() {
+	new_test_ext_at(JAN16_2026_MS).execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		deposit_credits(&user, 10_000, None);
+		purchase(&user, solo, None);
+		assert_eq!(Credits::get_free_credits(&user), 10_000 - SOLO_PRORATED);
+
+		assert_ok!(change_plan(&user, max));
+
+		// Total out of pocket for January is exactly one prorated Max month:
+		// the 517 already paid for Solo carries over as a credit.
+		assert_eq!(Credits::get_free_credits(&user), 10_000 - MAX_PRORATED);
+	});
+}
+
+#[test]
+fn upgrade_is_rejected_atomically_when_the_delta_is_unaffordable() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		// One credit short of the upgrade delta.
+		deposit_credits(&user, SOLO_PRICE + (MAX_PRICE - SOLO_PRICE) - 1, None);
+		purchase(&user, solo, None);
+		let before = Credits::get_free_credits(&user);
+		let sub_before = storage_subscription(&user);
+
+		assert_noop!(
+			dispatch_change(&user, max),
+			pallet_marketplace::Error::<Runtime>::InsufficientFreeCredits,
+		);
+
+		assert_eq!(Credits::get_free_credits(&user), before, "no credits moved");
+		let sub_after = storage_subscription(&user);
+		assert_eq!(sub_after.id, sub_before.id, "subscription untouched");
+		assert_eq!(sub_after.package.id, solo);
+	});
+}
+
+// ── Downgrades ───────────────────────────────────────────────────────────
+
+#[test]
+fn downgrade_costs_nothing_now_and_bills_the_cheaper_plan_next_month() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		deposit_credits(&user, MAX_PRICE, None);
+		purchase(&user, max, None);
+		assert_eq!(Credits::get_free_credits(&user), 0);
+
+		assert_ok!(change_plan(&user, solo));
+
+		// The month already bought is not refunded — the same rule the cancel
+		// path applies to the current month — but it fully covers the cheaper
+		// plan, so nothing is charged either.
+		assert_eq!(Credits::get_free_credits(&user), 0);
+		let sub = storage_subscription(&user);
+		assert_eq!(sub.package.id, solo);
+		assert_eq!(sub.paid_per_month, SOLO_PRICE, "next month bills Solo");
+		assert_eq!(sub.next_charge_unix_day, Some(FEB1_2026_DAY));
+	});
+}
+
+#[test]
+fn prepaid_months_pay_for_the_new_plan_before_free_credits_do() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		// 3 upfront Solo months on the 1st = 3 full months.
+		deposit_credits(&user, 3 * SOLO_PRICE, None);
+		purchase(&user, solo, Some(3));
+		assert_eq!(Credits::get_free_credits(&user), 0);
+		assert_eq!(storage_subscription(&user).next_charge_unix_day, Some(APR1_2026_DAY));
+
+		// Upgrading to Max: Feb + Mar (2_000) are refunded and January's Solo
+		// month (1_000) carries over, which together cover Max's 3_000 exactly.
+		// Net movement is zero and the user never needs spare credits.
+		assert_ok!(change_plan(&user, max));
+
+		assert_eq!(Credits::get_free_credits(&user), 0, "settled by netting alone");
+		let sub = storage_subscription(&user);
+		assert_eq!(sub.package.id, max);
+		assert_eq!(sub.next_charge_unix_day, Some(FEB1_2026_DAY));
+	});
+}
+
+#[test]
+fn surplus_prepaid_months_are_refunded_as_one_net_movement() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		// 3 upfront Max months (9_000), then downgrade to Solo on the 1st.
+		deposit_credits(&user, 3 * MAX_PRICE, None);
+		purchase(&user, max, Some(3));
+		assert_eq!(Credits::get_free_credits(&user), 0);
+
+		// Refund = Feb + Mar of Max = 6_000. Charge = Solo's January (1_000)
+		// minus the Max January already paid ⇒ 0. Net refund = 6_000.
+		assert_ok!(change_plan(&user, solo));
+
+		assert_eq!(Credits::get_free_credits(&user), 6_000);
+		assert_eq!(storage_subscription(&user).next_charge_unix_day, Some(FEB1_2026_DAY));
+	});
+}
+
+// ── Not a cancel: no gap, no cooldown, no lost attribution ───────────────
+
+#[test]
+fn change_leaves_no_entitlement_gap_and_arms_no_resubscribe_cooldown() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+
+		deposit_credits(&user, 10_000, None);
+		purchase(&user, solo, None);
+		let old_id = storage_subscription(&user).id;
+
+		assert_ok!(change_plan(&user, max));
+
+		// Exactly one storage subscription throughout — the slot was replaced,
+		// never emptied, so the user is never without a storage entitlement.
+		let subs = Marketplace::user_all_subscription_plans(&user);
+		assert_eq!(subs.iter().filter(|s| s.active && s.package.is_storage_plan).count(), 1);
+		let sub = storage_subscription(&user);
+		assert_ne!(sub.id, old_id, "a fresh subscription id is issued");
+		assert_eq!(sub.package.storage_limit, Some(MAX_PRICE * 1_000));
+
+		// The cooldown that forces cancel + re-purchase across blocks is never armed…
+		assert_eq!(Marketplace::last_subscription_cancelled_at(&user), None);
+		// …so a second change lands in the very same block.
+		assert_ok!(change_plan(&user, solo));
+		assert_eq!(storage_subscription(&user).package.id, solo);
+	});
+}
+
+#[test]
+fn referral_attribution_survives_and_commission_follows_the_net_charge() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let referrer = account(10);
+		let user = account(11);
+		let code = new_referral_code(&referrer);
+		let _ = Balances::deposit_creating(&referrer, ED);
+
+		// Referred purchase: 5% off Solo (950 charged), 5% commission = 47.
+		deposit_credits(&user, 10_000, Some(code.clone()));
+		purchase(&user, solo, None);
+		assert_eq!(Credits::get_free_credits(&user), 10_000 - 950);
+		assert_eq!(Balances::free_balance(&referrer), ED + 47);
+
+		// Upgrade: Max discounted to 2_850, less the 950 Solo month already
+		// paid ⇒ 1_900 charged, commission ⌊1_900 × 5%⌋ = 95.
+		assert_ok!(change_plan(&user, max));
+
+		assert_eq!(Credits::get_free_credits(&user), 10_000 - 950 - 1_900);
+		assert_eq!(Balances::free_balance(&referrer), ED + 47 + 95);
+		assert_eq!(Credits::referred_users(&user), Some(code), "attribution untouched");
+		assert_eq!(storage_subscription(&user).paid_per_month, 2_850);
+	});
+}
+
+// ── Guards ───────────────────────────────────────────────────────────────
+
+#[test]
+fn only_whitelisted_callers_may_change_a_plan() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+		deposit_credits(&user, 10_000, None);
+		purchase(&user, solo, None);
+
+		assert_err!(
+			Marketplace::change_storage_plan(
+				RuntimeOrigin::signed(account(99)),
+				user.clone(),
+				max,
+				None,
+				None,
+				None,
+			),
+			pallet_marketplace::Error::<Runtime>::WhitelistedCallerNotAuthorized,
+		);
+		// Not even the subscriber themselves.
+		assert_err!(
+			Marketplace::change_storage_plan(
+				RuntimeOrigin::signed(user.clone()),
+				user.clone(),
+				max,
+				None,
+				None,
+				None,
+			),
+			pallet_marketplace::Error::<Runtime>::WhitelistedCallerNotAuthorized,
+		);
+		assert_eq!(storage_subscription(&user).package.id, solo);
+	});
+}
+
+#[test]
+fn a_user_without_an_active_storage_subscription_cannot_change_plan() {
+	new_test_ext().execute_with(|| {
+		let (_solo, max) = ladder();
+		let user = account(11);
+		deposit_credits(&user, 10_000, None);
+
+		assert_err!(
+			change_plan(&user, max),
+			pallet_marketplace::Error::<Runtime>::NoActiveSubscription,
+		);
+
+		// A compute-only subscriber is equally out of scope for this call.
+		let compute = add_plan(b"compute", SOLO_PRICE, false);
+		purchase(&user, compute, None);
+		assert_err!(
+			change_plan(&user, max),
+			pallet_marketplace::Error::<Runtime>::NoActiveSubscription,
+		);
+	});
+}
+
+#[test]
+fn the_target_plan_must_be_a_different_live_storage_plan() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+		deposit_credits(&user, 10_000, None);
+		purchase(&user, solo, None);
+
+		// Same plan is a no-op the backend should not be able to bill for.
+		assert_err!(change_plan(&user, solo), pallet_marketplace::Error::<Runtime>::InvalidInput);
+
+		// Unknown plan.
+		assert_err!(
+			change_plan(&user, <Runtime as frame_system::Config>::Hashing::hash_of(&b"nope")),
+			pallet_marketplace::Error::<Runtime>::PlanNotFound,
+		);
+
+		// Compute plans are not a storage-plan target.
+		let compute = add_plan(b"compute", MAX_PRICE, false);
+		assert_err!(
+			change_plan(&user, compute),
+			pallet_marketplace::Error::<Runtime>::InvalidPlanType,
+		);
+
+		// Suspended target.
+		assert_ok!(Marketplace::set_package_suspension(RuntimeOrigin::root(), max, true));
+		assert_err!(change_plan(&user, max), pallet_marketplace::Error::<Runtime>::PlanSuspended);
+
+		assert_eq!(storage_subscription(&user).package.id, solo);
+	});
+}
+
+#[test]
+fn the_purchase_plan_kill_switch_also_stops_plan_changes() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+		deposit_credits(&user, 10_000, None);
+		purchase(&user, solo, None);
+
+		assert_ok!(Marketplace::sudo_set_purchase_plan_enabled(RuntimeOrigin::root(), false));
+		assert_err!(
+			change_plan(&user, max),
+			pallet_marketplace::Error::<Runtime>::PlanOperationDisabled,
+		);
+	});
+}
+
+#[test]
+fn plan_changes_are_rate_limited_per_block_like_purchases() {
+	new_test_ext().execute_with(|| {
+		let (solo, max) = ladder();
+		let user = account(11);
+		deposit_credits(&user, 100_000, None);
+		purchase(&user, solo, None);
+
+		// `MaxRequestsPerBlock` is 5 and the purchase consumed one, so four
+		// changes fit and the fifth is refused.
+		for i in 0..4 {
+			let target = if i % 2 == 0 { max } else { solo };
+			assert_ok!(change_plan(&user, target));
+		}
+		assert_err!(change_plan(&user, max), pallet_marketplace::Error::<Runtime>::TooManyRequests);
+
+		// The counter is cleared on the pallet's 15-block boundary.
+		System::set_block_number(15);
+		<Marketplace as Hooks<u64>>::on_initialize(15);
+		assert_ok!(change_plan(&user, max));
+	});
+}


### PR DESCRIPTION
Adds one extrinsic that moves a user's active storage subscription onto a different storage plan in a single dispatch, replacing the cancel + re-purchase pair the backend has to use today.

Cancel + re-purchase is not a plan change: it opens a window with no storage entitlement, the re-purchase re-checks the MinSubscriptionBlocks resubscribe cooldown (forcing the relayer to sequence across blocks and retry on ResubscribeCooldownActive), and it splits the refund and the new charge into two credit movements that bill the current month twice.

change_storage_plan replaces the subscription slot in place (no gap, cannot trip MaxActiveSubscriptions), never writes LastSubscriptionCancelledAt, and leaves referral attribution untouched. Same whitelist ACL, is_purchase_plan kill switch and per-block rate limit as purchase_plan.

Money model — one net FreeCredits movement:
- unused prepaid full months on the old plan refund exactly as they do on cancel;
- the unexpired part of the current month is credited against the new plan's first month, floored at zero and never paid out. Refunds mint credits with no alpha backing while charges release alpha from the user's batches, so paying the difference out on a downgrade would make A->B->A a free cycling loop on a call that has no cooldown. Capping closes that and still removes the double-charge on upgrades.
- refund is netted against the charge, so prepaid months can pay for the new plan directly and affordability is checked against the net delta before any state change.

Referral commission is computed on the net charge so refunded months do not pay commission twice.

Also excludes the call from ProxyType::NonTransfer alongside purchase_plan — an upgrade consumes credits, the same principal drain — and bumps spec_version to 92003. transaction_version is unchanged: the call takes a previously-unused index and no existing signature changed.

Covered by 13 runtime integration tests in
runtime/mainnet/tests/change_storage_plan.rs.