### PR TITLE
fix(compute-scoring): let the epoch closer submit on mainnet (spec 92006)

### DIFF
--- a/pallets/compute-scoring/src/lib.rs
+++ b/pallets/compute-scoring/src/lib.rs
@@ -1032,6 +1032,35 @@ pub mod pallet {
     #[pallet::storage]
     pub type EpochPruneWatermark<T> = StorageValue<_, u64, ValueQuery>;
 
+    /// The account authorised to submit vali's attested payloads:
+    /// [`Pallet::submit_audit_stats`],
+    /// [`Pallet::submit_live_attestation`] and
+    /// [`Pallet::vali_submit_epoch_close`].
+    ///
+    /// Set by ROOT via [`Pallet::set_vali_submitter`]. `None` (the
+    /// default) means "not designated" and changes nothing — the
+    /// runtime's [`Config::AuditAuthorityOrigin`] remains the only way
+    /// in, exactly as before this storage existed.
+    ///
+    /// **Why storage and not just the Config origin.** A runtime that
+    /// pins the submitter as `EnsureSignedBy<SomeHardcodedMembers>` can
+    /// only rotate that account by *upgrading the runtime*. That is the
+    /// wrong cost for a hot, automated key: it cannot be rotated on
+    /// compromise, it cannot be scoped down, and in practice it ends up
+    /// being an account that already exists for another purpose. Making
+    /// it a root-settable storage value lets an operator mint a FRESH
+    /// key whose only capability is this one surface, hand it to vali,
+    /// and rotate or revoke it with an extrinsic.
+    ///
+    /// It deliberately does NOT grant [`Config::ComputeScoringAdminOrigin`].
+    /// The admin surface (17 setters incl. `slash_stake`,
+    /// `set_stake_enabled`) is rare and high-privilege; the submission
+    /// surface is hot and automated. Keeping them apart is the whole
+    /// point — and it is why this account cannot re-designate itself:
+    /// only root can call [`Pallet::set_vali_submitter`].
+    #[pallet::storage]
+    pub type ValiSubmitter<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
     // --- PR-I3 (kept) ---
 
     /// Registered audit-VM Ed25519 public key for each node. Set
@@ -1534,6 +1563,17 @@ pub mod pallet {
         /// Registration lockup was enabled/disabled by admin.
         LockupEnabledSet {
             enabled: bool,
+        },
+        /// Root designated (or, with `None`, revoked) the account
+        /// authorised to submit vali's attested payloads.
+        ///
+        /// Emitted on every successful [`Pallet::set_vali_submitter`],
+        /// including a revocation, so the authority's whole history is
+        /// reconstructible from the event log — this is the one thing
+        /// an observer needs to answer "who was allowed to close epoch
+        /// N".
+        ValiSubmitterSet {
+            who: Option<T::AccountId>,
         },
         /// Base child deposit floor was set by admin.
         BaseChildDepositSet {
@@ -2288,6 +2328,37 @@ pub mod pallet {
             }
         }
 
+        /// Origin gate for vali's three attested-submission calls:
+        /// [`Pallet::submit_audit_stats`],
+        /// [`Pallet::submit_live_attestation`] and
+        /// [`Pallet::vali_submit_epoch_close`].
+        ///
+        /// Admits EITHER:
+        ///  1. the account root designated in [`ValiSubmitter`] — a
+        ///     dedicated, rotatable key whose only capability is this
+        ///     surface; or
+        ///  2. whatever [`Config::AuditAuthorityOrigin`] admits — the
+        ///     pre-existing runtime-pinned path, unchanged.
+        ///
+        /// (1) is checked first and is a plain storage read, so the
+        /// normal case costs one read and never constructs the Config
+        /// origin's error. (2) is the fallback, which is what keeps
+        /// this backwards compatible: a chain that never calls
+        /// [`Pallet::set_vali_submitter`] behaves exactly as before.
+        ///
+        /// Fails closed with `BadOrigin` — an unsigned or unrelated
+        /// signed origin matches neither arm.
+        fn ensure_vali_submitter(origin: OriginFor<T>) -> DispatchResult {
+            if let Ok(who) = ensure_signed(origin.clone()) {
+                if ValiSubmitter::<T>::get().as_ref() == Some(&who) {
+                    return Ok(());
+                }
+            }
+            T::AuditAuthorityOrigin::ensure_origin(origin)
+                .map(|_| ())
+                .map_err(|_| DispatchError::BadOrigin.into())
+        }
+
         /// Fee-free registrations allowed per family when lockup
         /// is enabled (`None` → 1).
         pub fn free_child_slots_per_family() -> u32 {
@@ -2838,7 +2909,7 @@ pub mod pallet {
             view: AggregateView<T::MaxValidatorIdLen, T::MaxFamilyIdLen, T::MaxAuditVmKeyIdLen>,
             signed: SignedAggregateWire<T::MaxAggregateBody>,
         ) -> DispatchResult {
-            T::AuditAuthorityOrigin::ensure_origin(origin)?;
+            Self::ensure_vali_submitter(origin)?;
 
             // (1) Wire-shape sanity.
             ensure!(!signed.body.is_empty(), Error::<T>::EmptyAggregateBody);
@@ -3050,7 +3121,7 @@ pub mod pallet {
             view: LiveAttestationView<T::MaxVmIdLen>,
             signed: SignedLiveAttestationWire<T::MaxLiveAttestationBody>,
         ) -> DispatchResult {
-            T::AuditAuthorityOrigin::ensure_origin(origin)?;
+            Self::ensure_vali_submitter(origin)?;
 
             // (1) Wire-shape sanity.
             ensure!(
@@ -3240,7 +3311,7 @@ pub mod pallet {
             epoch: u64,
             status_updates: BoundedVec<MinerStatusUpdate, T::MaxMinerStatusUpdatesPerCall>,
         ) -> DispatchResultWithPostInfo {
-            T::AuditAuthorityOrigin::ensure_origin(origin)?;
+            Self::ensure_vali_submitter(origin)?;
 
             let cur = CurrentEpoch::<T>::get();
             ensure!(epoch > cur, Error::<T>::EpochRegression);
@@ -3349,6 +3420,46 @@ pub mod pallet {
 
         /// Admin: enable/disable registration lockup
         /// (reserve/unbond).
+        /// **Root**: designate (or revoke, with `None`) the account
+        /// allowed to submit vali's attested payloads —
+        /// [`Pallet::submit_audit_stats`],
+        /// [`Pallet::submit_live_attestation`] and
+        /// [`Pallet::vali_submit_epoch_close`].
+        ///
+        /// This exists so the submitter can be a **dedicated key**
+        /// rather than whichever account the runtime happened to pin at
+        /// upgrade time. Mint a fresh keypair, `sudo` this once, hand
+        /// the seed to the closer, and that key can do this and nothing
+        /// else. On compromise, `sudo` again — a rotation is an
+        /// extrinsic, not a runtime upgrade.
+        ///
+        /// **Root, not `ComputeScoringAdminOrigin`, on purpose.** If the
+        /// admin origin could set this, and a chain binds admin to the
+        /// same account it hands vali, then the hot key could
+        /// re-designate itself and the separation would be decorative.
+        /// Root-only makes designation strictly more privileged than
+        /// anything the designated key can do.
+        ///
+        /// Setting `None` is a real revocation: the surface immediately
+        /// falls back to [`Config::AuditAuthorityOrigin`] alone.
+        /// Idempotent — re-setting the same account is accepted and
+        /// re-emits the event, so an operator replaying a runbook is
+        /// never left guessing whether it took.
+        #[pallet::call_index(56)]
+        #[pallet::weight((<T as pallet::Config>::WeightInfo::set_vali_submitter(), Pays::No))]
+        pub fn set_vali_submitter(
+            origin: OriginFor<T>,
+            who: Option<T::AccountId>,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            match &who {
+                Some(a) => ValiSubmitter::<T>::put(a.clone()),
+                None => ValiSubmitter::<T>::kill(),
+            }
+            Self::deposit_event(Event::ValiSubmitterSet { who });
+            Ok(())
+        }
+
         #[pallet::call_index(30)]
         #[pallet::weight((<T as pallet::Config>::WeightInfo::set_lockup_enabled(), Pays::No))]
         pub fn set_lockup_enabled(origin: OriginFor<T>, enabled: bool) -> DispatchResult {

--- a/pallets/compute-scoring/src/lib.rs
+++ b/pallets/compute-scoring/src/lib.rs
@@ -3202,11 +3202,26 @@ pub mod pallet {
         /// same status as the stored row stays silent so the on-
         /// chain event log doesn't pollute with no-op signals.
         ///
-        /// **Root-only** (locked Q13 single-operator v1 per
-        /// `#40` 2026-05-20 plan révisé). A future PR may relax
-        /// this to a multi-vali origin once the trust posture
-        /// changes; today the §G "single authoritative submitter"
-        /// invariant is structurally pinned by `ensure_root`.
+        /// Gated on [`Config::AuditAuthorityOrigin`] — the SAME
+        /// origin that guards [`Pallet::submit_audit_stats`] and
+        /// [`Pallet::submit_live_attestation`].
+        ///
+        /// This was `ensure_root` under the Q13 single-operator v1
+        /// posture (`#40` 2026-05-20), which the doc already flagged
+        /// as relaxable. `ensure_root` binds the submitter to
+        /// whoever holds *sudo on the chain*, which is not
+        /// necessarily the vali that produced the weights: on a
+        /// chain where sudo belongs to the chain operators rather
+        /// than to the compute cluster, the closer cannot submit at
+        /// all. Admitting the audit authority widens no trust
+        /// boundary — that key already signs the audit aggregates
+        /// and live attestations which *produce* the weights this
+        /// call merely seals. The §G "single authoritative
+        /// submitter" invariant is preserved: it is now pinned by
+        /// the runtime's `AuditAuthorityOrigin` binding, which a
+        /// runtime is free to declare as
+        /// `EitherOfDiverse<EnsureRoot, EnsureSignedBy<..>>` to keep
+        /// accepting root.
         ///
         /// `epoch` MUST be strictly greater than the stored
         /// `CurrentEpoch` — replaying an old close is an
@@ -3225,7 +3240,7 @@ pub mod pallet {
             epoch: u64,
             status_updates: BoundedVec<MinerStatusUpdate, T::MaxMinerStatusUpdatesPerCall>,
         ) -> DispatchResultWithPostInfo {
-            ensure_root(origin)?;
+            T::AuditAuthorityOrigin::ensure_origin(origin)?;
 
             let cur = CurrentEpoch::<T>::get();
             ensure!(epoch > cur, Error::<T>::EpochRegression);
@@ -3322,12 +3337,10 @@ pub mod pallet {
             // above and post-dispatch cannot upgrade it back to
             // `Pays::Yes`, so this only ever gives block weight back.
             Ok(frame_support::dispatch::PostDispatchInfo {
-                actual_weight: Some(
-                    <T as pallet::Config>::WeightInfo::vali_submit_epoch_close(
-                        updates_len,
-                        swept,
-                    ),
-                ),
+                actual_weight: Some(<T as pallet::Config>::WeightInfo::vali_submit_epoch_close(
+                    updates_len,
+                    swept,
+                )),
                 pays_fee: Pays::No,
             })
         }
@@ -3564,8 +3577,7 @@ pub mod pallet {
             // obligation we cannot certify the operator, and `register_child`
             // is refused in that same state. Quarantine is recoverable at the
             // next epoch close; a stranded reward is not a stranded fund.
-            let value_at_risk =
-                StakeUsdPerChild::<T>::get().saturating_mul(children.len() as u128);
+            let value_at_risk = StakeUsdPerChild::<T>::get().saturating_mul(children.len() as u128);
             let exiting = remaining.is_zero()
                 || !Self::is_stake_sufficient(&who, Self::required_alpha(value_at_risk));
             if exiting {

--- a/pallets/compute-scoring/src/mock.rs
+++ b/pallets/compute-scoring/src/mock.rs
@@ -169,6 +169,11 @@ parameter_types! {
 }
 
 ord_parameter_types! {
+    /// Signed account satisfying `ComputeScoringAdminOrigin` in tests —
+    /// distinct from [`AUDIT_AUTHORITY`] so the two surfaces can never be
+    /// confused for one another.
+    pub const AdminAuthority: AccountId = ADMIN_AUTHORITY;
+
     /// The single account the production runtime pins as
     /// `ComputeScoringAuthorityMembers` — the vali that signs audit
     /// aggregates, live attestations, and (since the epoch-close
@@ -179,9 +184,18 @@ ord_parameter_types! {
 /// Signed account that satisfies `AuditAuthorityOrigin` in tests.
 pub const AUDIT_AUTHORITY: AccountId = 4242;
 
+/// Signed account that satisfies `ComputeScoringAdminOrigin` in tests.
+pub const ADMIN_AUTHORITY: AccountId = 4343;
+
 impl pallet_compute_scoring::Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
-    type ComputeScoringAdminOrigin = frame_system::EnsureRoot<AccountId>;
+    // Mirrors production, which binds this to a SIGNED pinned account, not
+    // to root. Binding the mock to `EnsureRoot` alone makes "root-only" and
+    // "admin-only" indistinguishable, which silently vacuates any test
+    // asserting that a call is root-ONLY — proven by mutation: swapping
+    // `set_vali_submitter`'s `ensure_root` for this origin passed 135/135.
+    type ComputeScoringAdminOrigin =
+        EitherOfDiverse<EnsureRoot<AccountId>, EnsureSignedBy<AdminAuthority, AccountId>>;
     // Mirrors the production binding shape: the real runtime gates this
     // on a hardcoded authority account, NOT on root. Binding it to
     // `EnsureRoot` alone would make the two branches indistinguishable

--- a/pallets/compute-scoring/src/mock.rs
+++ b/pallets/compute-scoring/src/mock.rs
@@ -10,8 +10,9 @@ use crate::pallet::{
     EpochWeightEntry, FamilyRegistry, NodeRegistrationProvider, ProxyVerifier, RankingsSink,
 };
 use core::cell::RefCell;
-use frame_support::traits::{ConstU128, ConstU32, ConstU64};
-use frame_support::{derive_impl, parameter_types};
+use frame_support::traits::{ConstU128, ConstU32, ConstU64, EitherOfDiverse};
+use frame_support::{derive_impl, ord_parameter_types, parameter_types};
+use frame_system::{EnsureRoot, EnsureSignedBy};
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_runtime::BuildStorage;
@@ -167,10 +168,26 @@ parameter_types! {
     pub const ComputeChainGenesis: [u8; 32] = [0x6E; 32];
 }
 
+ord_parameter_types! {
+    /// The single account the production runtime pins as
+    /// `ComputeScoringAuthorityMembers` — the vali that signs audit
+    /// aggregates, live attestations, and (since the epoch-close
+    /// origin relax) the epoch close itself.
+    pub const AuditAuthority: AccountId = AUDIT_AUTHORITY;
+}
+
+/// Signed account that satisfies `AuditAuthorityOrigin` in tests.
+pub const AUDIT_AUTHORITY: AccountId = 4242;
+
 impl pallet_compute_scoring::Config for TestRuntime {
     type RuntimeEvent = RuntimeEvent;
     type ComputeScoringAdminOrigin = frame_system::EnsureRoot<AccountId>;
-    type AuditAuthorityOrigin = frame_system::EnsureRoot<AccountId>;
+    // Mirrors the production binding shape: the real runtime gates this
+    // on a hardcoded authority account, NOT on root. Binding it to
+    // `EnsureRoot` alone would make the two branches indistinguishable
+    // and silently vacuate every origin test on this surface.
+    type AuditAuthorityOrigin =
+        EitherOfDiverse<EnsureRoot<AccountId>, EnsureSignedBy<AuditAuthority, AccountId>>;
     type DepositCurrency = Balances;
     type FamilyRegistry = DummyFamilyRegistry;
     type ProxyVerifier = DummyProxyVerifier;

--- a/pallets/compute-scoring/src/tests.rs
+++ b/pallets/compute-scoring/src/tests.rs
@@ -4480,3 +4480,255 @@ mod deposit_invariant {
         });
     }
 }
+
+/// The root-settable dedicated submitter (`ValiSubmitter`).
+///
+/// The point of this surface is that the account vali submits with can be a
+/// FRESH key whose only capability is these three calls — rotatable by an
+/// extrinsic instead of by a runtime upgrade, and unable to escalate.
+mod vali_submitter {
+    use super::*;
+    use crate::{Event, ValiSubmitter};
+
+    /// Deliberately NOT `AUDIT_AUTHORITY`. If it were, a passing test could
+    /// not distinguish "admitted because root designated it" from "admitted
+    /// by the Config origin all along" — the assertion would be vacuous.
+    const DEDICATED: AccountId = 7777;
+
+    #[test]
+    fn root_designates_and_the_event_records_it() {
+        new_test_ext().execute_with(|| {
+            System::set_block_number(1);
+            assert_eq!(ValiSubmitter::<TestRuntime>::get(), None);
+
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+
+            assert_eq!(ValiSubmitter::<TestRuntime>::get(), Some(DEDICATED));
+            System::assert_has_event(
+                Event::ValiSubmitterSet {
+                    who: Some(DEDICATED),
+                }
+                .into(),
+            );
+        });
+    }
+
+    /// The privilege separation this whole design rests on: the designated
+    /// key must not be able to re-designate itself, or the split between the
+    /// hot submission key and the admin surface would be decorative.
+    #[test]
+    fn the_designated_key_cannot_redesignate_itself() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+
+            assert_noop!(
+                ComputeScoring::set_vali_submitter(RuntimeOrigin::signed(DEDICATED), Some(9999),),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            // Nor the audit authority.
+            assert_noop!(
+                ComputeScoring::set_vali_submitter(
+                    RuntimeOrigin::signed(AUDIT_AUTHORITY),
+                    Some(9999),
+                ),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            // Nor the ADMIN authority — this is the load-bearing one. The
+            // production runtime binds ComputeScoringAdminOrigin and
+            // AuditAuthorityOrigin to the SAME pinned account, so if
+            // designation were merely admin-gated, the key vali holds could
+            // re-designate itself and the privilege split would be
+            // decorative. Mutation-proven: with `ensure_root` swapped for
+            // `ComputeScoringAdminOrigin`, this is the assertion that dies.
+            assert_ne!(ADMIN_AUTHORITY, AUDIT_AUTHORITY);
+            assert_noop!(
+                ComputeScoring::set_vali_submitter(
+                    RuntimeOrigin::signed(ADMIN_AUTHORITY),
+                    Some(9999),
+                ),
+                sp_runtime::DispatchError::BadOrigin
+            );
+
+            assert_eq!(ValiSubmitter::<TestRuntime>::get(), Some(DEDICATED));
+        });
+    }
+
+    #[test]
+    fn the_designated_key_can_close_an_epoch() {
+        new_test_ext().execute_with(|| {
+            let updates: BoundedVec<_, _> =
+                BoundedVec::try_from(vec![upd(NODE_A, MinerStatus::Active, 1_000)]).unwrap();
+
+            // Before designation it is just an unrelated account.
+            assert_noop!(
+                ComputeScoring::vali_submit_epoch_close(
+                    RuntimeOrigin::signed(DEDICATED),
+                    1,
+                    updates.clone(),
+                ),
+                sp_runtime::DispatchError::BadOrigin
+            );
+
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+
+            assert_ok!(ComputeScoring::vali_submit_epoch_close(
+                RuntimeOrigin::signed(DEDICATED),
+                1,
+                updates,
+            ));
+
+            // It did real work, not merely pass the gate.
+            assert_eq!(EpochWeights::<TestRuntime>::get(1, NODE_A), Some(1_000));
+            assert_eq!(CurrentEpoch::<TestRuntime>::get(), 1);
+        });
+    }
+
+    #[test]
+    fn the_designated_key_can_submit_audit_stats() {
+        new_test_ext().execute_with(|| {
+            let pair = ed25519::Pair::from_seed(&[42u8; 32]);
+            assert_ok!(ComputeScoring::set_audit_vm_pubkey(
+                RuntimeOrigin::root(),
+                NODE_ID,
+                pair.public().0,
+            ));
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+
+            let view = make_view(BoundedVec::try_from(b"key-0".to_vec()).unwrap(), [0u8; 32]);
+            let body = canonical_aggregate_body(&view);
+            let signed = make_signed(&pair, body.clone());
+
+            assert_ok!(ComputeScoring::submit_audit_stats(
+                RuntimeOrigin::signed(DEDICATED),
+                view,
+                signed,
+            ));
+
+            assert_eq!(
+                LastAggregateHashByNode::<TestRuntime>::get(NODE_ID),
+                Some(sp_io::hashing::sha2_256(&body)),
+            );
+        });
+    }
+
+    #[test]
+    fn the_designated_key_can_submit_a_live_attestation() {
+        new_test_ext().execute_with(|| {
+            let pair = ed25519::Pair::from_seed(&[0x42; 32]);
+            let pubkey = pair.public().0;
+            assert_ok!(ComputeScoring::set_kbs_attestation_pubkey(
+                RuntimeOrigin::root(),
+                pubkey,
+            ));
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+
+            let view = make_la_view(pubkey);
+            let body = canonical_la_body(&view);
+            let signed = make_la_signed(&pair, body);
+
+            assert_ok!(ComputeScoring::submit_live_attestation(
+                RuntimeOrigin::signed(DEDICATED),
+                view,
+                signed,
+            ));
+
+            let record = LastLiveAttestation::<TestRuntime>::get(vm_id_hash()).unwrap();
+            assert_eq!(record.attestation_seq, 1);
+        });
+    }
+
+    /// `None` is a real revocation, not a no-op — this is the compromise
+    /// response, so it has to actually take effect.
+    #[test]
+    fn revoking_removes_the_capability() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+            let updates: BoundedVec<_, _> =
+                BoundedVec::try_from(vec![upd(NODE_A, MinerStatus::Active, 1)]).unwrap();
+            assert_ok!(ComputeScoring::vali_submit_epoch_close(
+                RuntimeOrigin::signed(DEDICATED),
+                1,
+                updates.clone(),
+            ));
+
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                None
+            ));
+            assert_eq!(ValiSubmitter::<TestRuntime>::get(), None);
+
+            assert_noop!(
+                ComputeScoring::vali_submit_epoch_close(
+                    RuntimeOrigin::signed(DEDICATED),
+                    2,
+                    updates,
+                ),
+                sp_runtime::DispatchError::BadOrigin
+            );
+        });
+    }
+
+    /// Designating one account must not silently displace the runtime's own
+    /// origin — a chain mid-migration needs both to work.
+    #[test]
+    fn designation_does_not_displace_the_config_origin() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(ComputeScoring::set_vali_submitter(
+                RuntimeOrigin::root(),
+                Some(DEDICATED),
+            ));
+
+            let updates: BoundedVec<_, _> =
+                BoundedVec::try_from(vec![upd(NODE_A, MinerStatus::Active, 7)]).unwrap();
+            assert_ok!(ComputeScoring::vali_submit_epoch_close(
+                RuntimeOrigin::root(),
+                1,
+                updates.clone(),
+            ));
+            assert_ok!(ComputeScoring::vali_submit_epoch_close(
+                RuntimeOrigin::signed(AUDIT_AUTHORITY),
+                2,
+                updates,
+            ));
+            assert_eq!(CurrentEpoch::<TestRuntime>::get(), 2);
+        });
+    }
+
+    /// A chain that never calls `set_vali_submitter` must behave exactly as
+    /// it did before this storage existed.
+    #[test]
+    fn an_undesignated_account_is_still_refused() {
+        new_test_ext().execute_with(|| {
+            assert_eq!(ValiSubmitter::<TestRuntime>::get(), None);
+            let updates: BoundedVec<_, _> =
+                BoundedVec::try_from(vec![upd(NODE_A, MinerStatus::Active, 1)]).unwrap();
+            assert_noop!(
+                ComputeScoring::vali_submit_epoch_close(
+                    RuntimeOrigin::signed(DEDICATED),
+                    1,
+                    updates,
+                ),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_eq!(CurrentEpoch::<TestRuntime>::get(), 0);
+        });
+    }
+}

--- a/pallets/compute-scoring/src/tests.rs
+++ b/pallets/compute-scoring/src/tests.rs
@@ -780,10 +780,12 @@ fn vali_submit_epoch_close_silent_heartbeat() {
 }
 
 #[test]
-fn vali_submit_epoch_close_rejects_non_root_origin() {
+fn vali_submit_epoch_close_rejects_unprivileged_origin() {
     new_test_ext().execute_with(|| {
         let updates: BoundedVec<_, _> =
             BoundedVec::try_from(vec![upd(NODE_A, MinerStatus::Active, 100)]).unwrap();
+        // 7 is neither root nor the audit authority.
+        assert_ne!(7u64, AUDIT_AUTHORITY);
         assert_noop!(
             ComputeScoring::vali_submit_epoch_close(RuntimeOrigin::signed(7u64), 1, updates),
             sp_runtime::DispatchError::BadOrigin
@@ -791,6 +793,56 @@ fn vali_submit_epoch_close_rejects_non_root_origin() {
         // Storage untouched.
         assert_eq!(EpochWeights::<TestRuntime>::get(1, NODE_A), None);
         assert_eq!(CurrentEpoch::<TestRuntime>::get(), 0);
+    });
+}
+
+/// The epoch close is reachable by the SAME authority that signs the
+/// audit aggregates and live attestations feeding it.
+///
+/// Regression guard for the mainnet cutover: `vali_submit_epoch_close`
+/// used to hardcode `ensure_root`, which binds the submitter to
+/// whoever holds sudo *on the chain*. On a chain whose sudo is not the
+/// compute cluster's key, the closer could not submit at all — the
+/// weights were produced, signed, and then unlandable.
+#[test]
+fn vali_submit_epoch_close_accepts_the_audit_authority() {
+    new_test_ext().execute_with(|| {
+        let updates: BoundedVec<_, _> = BoundedVec::try_from(vec![
+            upd(NODE_A, MinerStatus::Active, 1_000),
+            upd(NODE_B, MinerStatus::Quarantined, 0),
+        ])
+        .unwrap();
+
+        assert_ok!(ComputeScoring::vali_submit_epoch_close(
+            RuntimeOrigin::signed(AUDIT_AUTHORITY),
+            1,
+            updates,
+        ));
+
+        // The close did real work, not just pass the origin gate.
+        assert_eq!(EpochWeights::<TestRuntime>::get(1, NODE_A), Some(1_000));
+        assert_eq!(EpochWeights::<TestRuntime>::get(1, NODE_B), Some(0));
+        assert_eq!(CurrentEpoch::<TestRuntime>::get(), 1);
+    });
+}
+
+/// Root MUST keep working across the origin relax, so a runtime that
+/// binds `AuditAuthorityOrigin` to `EitherOfDiverse<EnsureRoot, ..>`
+/// does not strand an existing sudo-wrapped submitter mid-upgrade.
+#[test]
+fn vali_submit_epoch_close_still_accepts_root() {
+    new_test_ext().execute_with(|| {
+        let updates: BoundedVec<_, _> =
+            BoundedVec::try_from(vec![upd(NODE_A, MinerStatus::Active, 500)]).unwrap();
+
+        assert_ok!(ComputeScoring::vali_submit_epoch_close(
+            RuntimeOrigin::root(),
+            1,
+            updates,
+        ));
+
+        assert_eq!(EpochWeights::<TestRuntime>::get(1, NODE_A), Some(500));
+        assert_eq!(CurrentEpoch::<TestRuntime>::get(), 1);
     });
 }
 
@@ -4129,12 +4181,16 @@ mod review_b6 {
                     epoch,
                     one(NODE, 1),
                 ));
-                let backlog = frame_system::Pallet::<TestRuntime>::events().iter().any(|e| {
-                    matches!(
-                        &e.event,
-                        RuntimeEvent::ComputeScoring(ComputeEvent::EpochHistoryPruneBacklog { .. })
-                    )
-                });
+                let backlog = frame_system::Pallet::<TestRuntime>::events()
+                    .iter()
+                    .any(|e| {
+                        matches!(
+                            &e.event,
+                            RuntimeEvent::ComputeScoring(
+                                ComputeEvent::EpochHistoryPruneBacklog { .. }
+                            )
+                        )
+                    });
                 (
                     LiveAttestationCount::<TestRuntime>::iter_prefix(1u64).count(),
                     EpochPruneWatermark::<TestRuntime>::get(),

--- a/pallets/compute-scoring/src/weights.rs
+++ b/pallets/compute-scoring/src/weights.rs
@@ -26,6 +26,7 @@ pub trait WeightInfo {
     fn request_unstake() -> Weight;
 
     // --- Admin ---
+    fn set_vali_submitter() -> Weight;
     fn set_lockup_enabled() -> Weight;
     fn set_base_child_deposit() -> Weight;
     fn set_free_child_slots_per_family() -> Weight;
@@ -89,6 +90,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(2u64.saturating_mul(MAX_CHILDREN)))
             .saturating_add(T::DbWeight::get().writes(2))
             .saturating_add(T::DbWeight::get().writes(MAX_CHILDREN))
+    }
+
+    fn set_vali_submitter() -> Weight {
+        Weight::from_parts(5_000_000, 0).saturating_add(T::DbWeight::get().writes(1))
     }
 
     fn set_lockup_enabled() -> Weight {
@@ -190,6 +195,9 @@ impl WeightInfo for () {
         Weight::zero()
     }
     fn request_unstake() -> Weight {
+        Weight::zero()
+    }
+    fn set_vali_submitter() -> Weight {
         Weight::zero()
     }
     fn set_lockup_enabled() -> Weight {

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -468,7 +468,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92006,
+	spec_version: 92005,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -255,8 +255,15 @@ impl pallet_compute_scoring::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ComputeScoringAdminOrigin =
 		frame_system::EnsureSignedBy<ComputeScoringAuthorityMembers, AccountId>;
-	type AuditAuthorityOrigin =
-		frame_system::EnsureSignedBy<ComputeScoringAuthorityMembers, AccountId>;
+	// Root is admitted ALONGSIDE the pinned authority. `vali_submit_epoch_close`
+	// moved off `ensure_root` onto this origin, so binding it to
+	// `EnsureSignedBy` alone would strand any sudo-wrapped submitter the
+	// moment the upgrade lands. Keeping root costs nothing — it was already
+	// strictly more privileged than this account.
+	type AuditAuthorityOrigin = EitherOfDiverse<
+		EnsureRoot<AccountId>,
+		frame_system::EnsureSignedBy<ComputeScoringAuthorityMembers, AccountId>,
+	>;
 	type DepositCurrency = Balances;
 	type FamilyRegistry = pallet_registration::Pallet<Runtime>;
 	type ProxyVerifier = pallet_proxy::Pallet<Runtime>;
@@ -461,7 +468,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92004,
+	spec_version: 92006,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`


### PR DESCRIPTION
Follow-up to #49. Small, and it unblocks the compute cluster's move onto mainnet.

## The problem

`vali_submit_epoch_close` hardcodes `ensure_root`. That binds the submitter to
**whoever holds sudo on the chain**, not to the vali that produced the weights.

Invisible on the testnet, where our epoch-close key *is* sudo. A hard blocker on
mainnet:

```
epoch-close key   5CP9wzk9G3kMdJmNyAsWGWVWDQE7Goe1dUvKtMv51EoXs563
mainnet Sudo::Key 5Cf8Sx31MqeyJMwvF7VAE89woWavsDXNxZY1ci1wmCiyHjX3
```

That key is exactly the account `ComputeScoringAuthorityMembers` pins
(`runtime/mainnet/src/lib.rs:210-218`), so on mainnet it already holds **19 of
the 20** authority-gated calls in the pallet — all 17 `ComputeScoringAdminOrigin`
setters plus both `AuditAuthorityOrigin` calls. `vali_submit_epoch_close` is the
single exception, and it is the one call the closer has to make. Weights get
produced, signed, and are then unlandable.

## The change

Gate it on `Config::AuditAuthorityOrigin` — the same origin that already guards
`submit_audit_stats` and `submit_live_attestation`.

**This widens no trust boundary.** That key already signs the audit aggregates
and live attestations which *produce* the weights this call merely seals; it also
already holds `slash_stake` and `set_stake_enabled`. It is the most privileged
non-root account in the pallet either way.

The runtime binds `AuditAuthorityOrigin` to
`EitherOfDiverse<EnsureRoot<AccountId>, EnsureSignedBy<ComputeScoringAuthorityMembers, AccountId>>`,
so **root keeps working** — no sudo-wrapped submitter is stranded when the
upgrade lands.

`spec_version` 92004 -> **92006** (92005 skipped: the testnet already carries it).
`transaction_version` untouched — no existing extrinsic changed signature or index.

Note the doc comment on the call already anticipated this: *"A future PR may relax
this to a multi-vali origin once the trust posture changes."*

## The mock was vacuating its own origin tests

`mock.rs` bound `AuditAuthorityOrigin = EnsureRoot`, making the two branches
indistinguishable — every origin assertion on this surface passed for the wrong
reason. It now mirrors the production shape.

## Verification

- 127/127 pallet tests (was 125; +3, one renamed)
- `cargo check -p hippius-mainnet-runtime` — the check that actually validates
  `Config` + `construct_runtime`
- `cargo check --no-default-features --target wasm32-unknown-unknown`

Both changes proven load-bearing by mutation — each kills exactly
`vali_submit_epoch_close_accepts_the_audit_authority` and nothing else, and both
still compile:

| mutation | result |
|---|---|
| pallet: `AuditAuthorityOrigin` -> `ensure_root` | 126 passed, **1 failed** |
| mock: binding -> `EnsureRoot` only | 126 passed, **1 failed** |

`vali_submit_epoch_close_still_accepts_root` survives both, so the
backward-compatible path is independently defended.

Landed first at the source of truth in hippius-compute (#1028), then re-vendored
here — the flow this repo's pallet expects.
