### PR TITLE
Feat/pay compute miners

### DIFF
--- a/pallets/compute-scoring/src/lib.rs
+++ b/pallets/compute-scoring/src/lib.rs
@@ -977,7 +977,19 @@ pub mod pallet {
     /// reward-critical number stored — one `u128::MAX` entry breaks
     /// every downstream normalisation. The default (`u64::MAX`)
     /// guarantees that even a full `MaxMinerStatusUpdatesPerCall`
-    /// batch sums far inside u128. Admin-tunable downward.
+    /// batch sums far inside u128.
+    ///
+    /// **No setter extrinsic exists**: this is reachable only via a
+    /// sudo `set_storage` or a migration. Treat the default as the
+    /// operative value.
+    ///
+    /// Downstream consumers rely on the batch-sum headroom this
+    /// bound provides, not merely on the per-entry cap —
+    /// `pallet_hippocampus::pay_compute_miners` sums a whole epoch's
+    /// weights into a `u128` denominator and its fund-conservation
+    /// argument breaks if that sum can saturate. Raising this value
+    /// toward `u128::MAX` is therefore NOT a local change; audit
+    /// every reader first.
     #[pallet::type_value]
     pub fn DefaultMaxEpochWeightPerNode() -> u128 {
         u64::MAX as u128

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -764,6 +764,29 @@ pub mod pallet {
 				.saturating_sub(EmissionPaidOut::<T>::get())
 		}
 
+		/// What `request_payment` may actually release: the free balance above
+		/// ED, minus BOTH emission compartments.
+		///
+		/// The compartments are reserved for `pay_storage_miners` /
+		/// `pay_compute_miners`, and that reservation has to be enforced here
+		/// rather than left to each caller. Callers that subtract it themselves
+		/// (the arion payout source, the referral commission path) clamp their
+		/// own amount first, so this second ceiling is a no-op for them; the
+		/// callers that don't — the sudo-refund retry and the chargeback refund
+		/// — were able to drain the bank down to ED while the compartment
+		/// ledger still showed a full balance, leaving `pay_compute_miners` to
+		/// fail with `InsufficientBankBalance` against emission that was
+		/// nominally reserved for it.
+		///
+		/// This bounds only what THIS pallet knows it owes. Runtime-level
+		/// reservations (undistributed marketplace backing, pending sudo
+		/// refunds) are still the caller's to subtract.
+		pub fn unreserved_for_payout() -> BalanceOf<T> {
+			Self::available_for_payout()
+				.saturating_sub(Self::emission_available())
+				.saturating_sub(Self::compute_emission_available())
+		}
+
 		/// Compute emission deposited but not yet distributed to compute
 		/// miners.
 		///
@@ -832,9 +855,12 @@ pub mod pallet {
 				Some(cap) => amount.min(cap),
 				None => amount,
 			};
+			// Clamped against the UNRESERVED balance, not the raw free balance:
+			// a requester must not be able to spend emission the bank is
+			// holding for the two miner payouts.
 			let paid: BalanceOf<T> = payment_math::payable(
 				Tokens::new(capped_amount.saturated_into()),
-				Tokens::new(Self::available_for_payout().saturated_into()),
+				Tokens::new(Self::unreserved_for_payout().saturated_into()),
 			)
 			.get()
 			.saturated_into();

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -80,6 +80,16 @@ pub mod pallet {
 		/// every node belonging to the same payee. A repeated account is not
 		/// unsound (it just receives several transfers), but it burns one of
 		/// the `MaxComputeMinersPerPayout` slots per node instead of per payee.
+		///
+		/// **Caller contract**: the returned weights MUST sum to strictly less
+		/// than `u128::MAX`. The bank folds them into a single `u128`
+		/// denominator with `saturating_add`; a sum that saturated would be an
+		/// under-sized denominator and the pro-rata shares could then exceed
+		/// the requested payout, overdrawing the compartment. The production
+		/// implementation inherits this from compute-scoring's per-entry
+		/// `MaxEpochWeightPerNode` cap over a bounded entry count — an
+		/// implementation without an equivalent per-entry bound must impose
+		/// one itself.
 		fn active_compute_miners() -> Vec<(AccountId, u128)>;
 	}
 
@@ -602,9 +612,23 @@ pub mod pallet {
 					<= T::MaxComputeMinersPerPayout::get(),
 				Error::<T>::TooManyComputeMiners
 			);
-			// Saturating: a saturated total is still >= every individual weight,
-			// so `weight_share`'s `weight <= total_weight` contract holds and
-			// the only consequence is shares rounding down.
+			// `saturating_add` here is an overflow guard, NOT a benign
+			// rounding choice: a total that actually saturated would be an
+			// UNDER-sized denominator, and `Σ weight_share(pool, wᵢ, total)`
+			// could then exceed `pool` — overdrawing the compartment and
+			// booking past the daily cap. (Two payees at `u128::MAX` would
+			// each receive the whole pool.) So conservation depends on the
+			// fold never saturating, which holds because the compute-scoring
+			// pallet caps every entry at `MaxEpochWeightPerNode` (default
+			// `u64::MAX`) before writing it and at most
+			// `MaxMinerStatusUpdatesPerCall` entries exist per epoch —
+			// a ceiling ~17 orders of magnitude below `u128::MAX`.
+			//
+			// That margin lives in ANOTHER pallet's constant. Anything that
+			// raises `MaxEpochWeightPerNode` toward `u128::MAX`, or a
+			// `ComputeMinerWeights` implementation that does not inherit that
+			// per-entry cap, must re-establish the bound here first — e.g. by
+			// rejecting a fold that saturates.
 			let total_weight: u128 =
 				miners.iter().fold(0u128, |acc, (_, w)| acc.saturating_add(*w));
 			ensure!(total_weight > 0, Error::<T>::NoEligibleComputeMiners);

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -14,6 +14,13 @@
 //!   `DistributionDisabled` while the global switch is off.
 //! - `pay_storage_miners(amount)`: admin-gated; distributes `amount` from the
 //!   emission compartment to ranked storage miners pro-rata by ranking weight.
+//! - `pay_compute_miners(amount)`: admin-gated; distributes `amount` from the
+//!   *compute* emission compartment to compute miners pro-rata by their
+//!   epoch reward weight. Its compartment (`DepositType::ComputeEmission`)
+//!   and its ledger (`ComputeEmissionPaidOut`) are separate from the storage
+//!   ones — neither payout can spend the other's funds — but the two share a
+//!   single 24-hour rate limit (`Max24HourMinerPayout`), so total emission
+//!   leaving the bank per day is capped once across both.
 //! - `add_requester` / `remove_requester`: admin-gated whitelist management.
 //! - `set_distribution_enabled`: admin-gated global switch. While off, every
 //!   `request_payment` is rejected and no funds leave the bank; deposits are
@@ -56,6 +63,26 @@ pub mod pallet {
 		fn active_storage_miners() -> Vec<(AccountId, u16)>;
 	}
 
+	/// Compute miners the bank distributes the compute emission compartment to.
+	///
+	/// Implemented by the runtime against the compute-scoring pallet's
+	/// per-epoch reward weights so the bank stays decoupled from where those
+	/// weights come from.
+	pub trait ComputeMinerWeights<AccountId> {
+		/// Payout account and reward weight of every compute miner eligible
+		/// for the current payout window. Zero-weight entries receive nothing.
+		///
+		/// Weights are `u128` (the compute-scoring `EpochWeights` width, not
+		/// the `u16` the storage ranking uses).
+		///
+		/// **Caller contract**: each payout account MUST appear at most once —
+		/// the implementation is responsible for aggregating the weights of
+		/// every node belonging to the same payee. A repeated account is not
+		/// unsound (it just receives several transfers), but it burns one of
+		/// the `MaxComputeMinersPerPayout` slots per node instead of per payee.
+		fn active_compute_miners() -> Vec<(AccountId, u128)>;
+	}
+
 	/// Version 1 is "activated": requesters whitelisted and pre-upgrade backing
 	/// seeded by `ActivateMinerPaymentBank`. That migration seeds real funds
 	/// from sudo, so it keys its one-shot guard on this rather than on
@@ -93,9 +120,18 @@ pub mod pallet {
 		#[pallet::constant]
 		type BlocksPer24Hours: Get<BlockNumberFor<Self>>;
 
-		/// Maximum emission to distribute to miners per 24-hour period (in planck).
+		/// Maximum emission to distribute to miners per 24-hour period (in
+		/// planck). A single budget shared by `pay_storage_miners` and
+		/// `pay_compute_miners`: what one spends the other cannot.
 		#[pallet::constant]
 		type Max24HourMinerPayout: Get<BalanceOf<Self>>;
+
+		/// Weighted compute miners paid by `pay_compute_miners`.
+		type ComputeMinerWeights: ComputeMinerWeights<Self::AccountId>;
+
+		/// Most compute miners a single `pay_compute_miners` call will pay.
+		#[pallet::constant]
+		type MaxComputeMinersPerPayout: Get<u32>;
 
 		type WeightInfo: WeightInfo;
 	}
@@ -114,6 +150,13 @@ pub mod pallet {
 		Fees,
 		/// Anything else.
 		Other,
+		/// Protocol emissions earmarked for compute miners. A separate
+		/// compartment from [`DepositType::Emission`] (which backs
+		/// `pay_storage_miners`): each is spendable only by its own payout.
+		///
+		/// Appended last on purpose — `DepositType` is a storage key, and the
+		/// existing variants must keep their SCALE discriminants.
+		ComputeEmission,
 	}
 
 	/// Global payout switch (defaults to enabled). While `false`,
@@ -149,14 +192,22 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type EmissionPaidOut<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
-	/// Amount distributed to storage miners in the current 24-hour period.
-	/// Resets every 24 hours. Max: 2952 alpha (emission per 24h).
+	/// Amount distributed to miners in the current 24-hour period — storage and
+	/// compute payouts draw on this **one** counter, bounded by
+	/// `Max24HourMinerPayout`. Resets every 24 hours.
 	#[pallet::storage]
 	pub type MinerPayoutPeriodAmount<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
 	/// Block number when the current 24-hour payout period started.
 	#[pallet::storage]
 	pub type MinerPayoutPeriodStart<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
+
+	/// Lifetime total distributed to compute miners out of the compute
+	/// emission compartment. `TotalDeposited[ComputeEmission] -
+	/// ComputeEmissionPaidOut` is the compartment balance still reserved for
+	/// `pay_compute_miners`.
+	#[pallet::storage]
+	pub type ComputeEmissionPaidOut<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
 	/// Lifetime total released per requester (e.g. arion vs compute escrow).
 	#[pallet::storage]
@@ -242,6 +293,17 @@ pub mod pallet {
 		MinerPaymentCallerAdded { who: T::AccountId },
 		/// An account was removed from the miner payment whitelist.
 		MinerPaymentCallerRemoved { who: T::AccountId },
+		/// `pay_compute_miners` distributed compute emission pro-rata by epoch
+		/// reward weight. `paid < requested` when shares rounded to zero or a
+		/// transfer was skipped; the difference stays in the compartment.
+		ComputeMinersPaid {
+			requested: BalanceOf<T>,
+			paid: BalanceOf<T>,
+			miners_paid: u32,
+			miners_skipped: u32,
+		},
+		/// Individual compute miner payment detail for indexing.
+		ComputeMinerPaymentPaid { miner: T::AccountId, amount: BalanceOf<T> },
 	}
 
 	#[pallet::error]
@@ -266,8 +328,16 @@ pub mod pallet {
 		NoEligibleMiners,
 		/// Caller is not whitelisted to call `pay_storage_miners`.
 		PaymentCallerNotWhitelisted,
-		/// 24-hour miner payout limit would be exceeded.
+		/// The shared 24-hour miner payout limit would be exceeded. Raised by
+		/// both `pay_storage_miners` and `pay_compute_miners`.
 		ExceedsDaily24HourMinerPayoutLimit,
+		/// `pay_compute_miners` asked for more than the compute emission
+		/// compartment holds.
+		InsufficientComputeEmissionFunds,
+		/// The weighted compute-miner list exceeds `MaxComputeMinersPerPayout`.
+		TooManyComputeMiners,
+		/// No compute miner carries a non-zero weight this window.
+		NoEligibleComputeMiners,
 	}
 
 	#[pallet::call]
@@ -469,6 +539,116 @@ pub mod pallet {
 			});
 			Ok(())
 		}
+
+		/// Distribute `amount` from the bank's **compute** emission compartment
+		/// to compute miners, pro-rata to their epoch reward weight.
+		///
+		/// Callable only by whitelisted miner-payment callers — the same
+		/// whitelist that gates `pay_storage_miners`, since both are driven by
+		/// the same admin-run payout key. The runtime's `ComputeMinerWeights`
+		/// implementation decides which nodes are eligible and which account
+		/// each node pays out to. Floor-division dust and skipped shares stay
+		/// in the compartment.
+		///
+		/// Shares the 24-hour `Max24HourMinerPayout` budget with
+		/// `pay_storage_miners` — the two compartments are separate pots, but
+		/// the daily drain rate is capped once across both.
+		#[pallet::call_index(9)]
+		#[pallet::weight(<T as Config>::WeightInfo::pay_compute_miners(T::MaxComputeMinersPerPayout::get()))]
+		pub fn pay_compute_miners(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			ensure!(
+				MinerPaymentWhitelist::<T>::contains_key(&who),
+				Error::<T>::PaymentCallerNotWhitelisted
+			);
+			ensure!(DistributionEnabled::<T>::get(), Error::<T>::DistributionDisabled);
+			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
+
+			// 24-hour rate limit — the SAME counter `pay_storage_miners` uses.
+			// `Max24HourMinerPayout` bounds total emission leaving the bank per
+			// day across both payouts, so what storage spends compute cannot,
+			// and vice versa. (The compartments below stay separate: a shared
+			// rate limit governs the pace, not the entitlement.)
+			let current_block = <frame_system::Pallet<T>>::block_number();
+			let period_start = MinerPayoutPeriodStart::<T>::get();
+			let blocks_per_24h = T::BlocksPer24Hours::get();
+			if current_block.saturating_sub(period_start) >= blocks_per_24h {
+				MinerPayoutPeriodStart::<T>::put(current_block);
+				MinerPayoutPeriodAmount::<T>::put(BalanceOf::<T>::zero());
+			}
+
+			let current_period_amount = MinerPayoutPeriodAmount::<T>::get();
+			let max_per_24h = T::Max24HourMinerPayout::get();
+			let new_period_amount = current_period_amount.saturating_add(amount);
+			ensure!(
+				new_period_amount <= max_per_24h,
+				Error::<T>::ExceedsDaily24HourMinerPayoutLimit
+			);
+
+			// Compartment wall: only funds deposited as `ComputeEmission` pay
+			// compute miners — never storage emission, marketplace backing,
+			// fees, or grants.
+			ensure!(
+				amount <= Self::compute_emission_available(),
+				Error::<T>::InsufficientComputeEmissionFunds
+			);
+			// The compartment ledger can exceed what is physically free (another
+			// consumer overdrew, or the ED cushion); never overdraw the account.
+			ensure!(amount <= Self::available_for_payout(), Error::<T>::InsufficientBankBalance);
+
+			let miners = T::ComputeMinerWeights::active_compute_miners();
+			ensure!(
+				u32::try_from(miners.len()).unwrap_or(u32::MAX)
+					<= T::MaxComputeMinersPerPayout::get(),
+				Error::<T>::TooManyComputeMiners
+			);
+			// Saturating: a saturated total is still >= every individual weight,
+			// so `weight_share`'s `weight <= total_weight` contract holds and
+			// the only consequence is shares rounding down.
+			let total_weight: u128 =
+				miners.iter().fold(0u128, |acc, (_, w)| acc.saturating_add(*w));
+			ensure!(total_weight > 0, Error::<T>::NoEligibleComputeMiners);
+
+			let bank = Self::account_id();
+			let pool = payment_math::Tokens::new(amount.saturated_into());
+			let mut paid: BalanceOf<T> = Zero::zero();
+			let mut miners_paid: u32 = 0;
+			let mut miners_skipped: u32 = 0;
+
+			for (owner, weight) in miners {
+				let share: BalanceOf<T> =
+					payment_math::weight_share(pool, weight, total_weight).get().saturated_into();
+				// Zero shares (weight rounds below one planck) and failed
+				// transfers (e.g. a reaped owner account below its ED) are
+				// skipped, not fatal: their share stays in the compartment.
+				if share.is_zero() {
+					miners_skipped = miners_skipped.saturating_add(1);
+					continue;
+				}
+				match T::Currency::transfer(&bank, &owner, share, ExistenceRequirement::KeepAlive) {
+					Ok(()) => {
+						paid = paid.saturating_add(share);
+						miners_paid = miners_paid.saturating_add(1);
+						Self::deposit_event(Event::ComputeMinerPaymentPaid {
+							miner: owner.clone(),
+							amount: share,
+						});
+					},
+					Err(_) => miners_skipped = miners_skipped.saturating_add(1),
+				}
+			}
+
+			ComputeEmissionPaidOut::<T>::mutate(|t| *t = t.saturating_add(paid));
+			TotalPaidOut::<T>::mutate(|t| *t = t.saturating_add(paid));
+			MinerPayoutPeriodAmount::<T>::mutate(|t| *t = t.saturating_add(paid));
+			Self::deposit_event(Event::ComputeMinersPaid {
+				requested: amount,
+				paid,
+				miners_paid,
+				miners_skipped,
+			});
+			Ok(())
+		}
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -509,6 +689,17 @@ pub mod pallet {
 		pub fn emission_available() -> BalanceOf<T> {
 			TotalDeposited::<T>::get(DepositType::Emission)
 				.saturating_sub(EmissionPaidOut::<T>::get())
+		}
+
+		/// Compute emission deposited but not yet distributed to compute
+		/// miners.
+		///
+		/// Like [`Self::emission_available`], other bank consumers must
+		/// subtract this from their spendable headroom — the compartment is
+		/// reserved for `pay_compute_miners`.
+		pub fn compute_emission_available() -> BalanceOf<T> {
+			TotalDeposited::<T>::get(DepositType::ComputeEmission)
+				.saturating_sub(ComputeEmissionPaidOut::<T>::get())
 		}
 
 		/// Transfer `amount` from `who` into the bank and record it. Shared by

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -91,6 +91,19 @@ pub mod pallet {
 		/// implementation without an equivalent per-entry bound must impose
 		/// one itself.
 		fn active_compute_miners() -> Vec<(AccountId, u128)>;
+
+		/// Identifier of the settlement period the weights above belong to,
+		/// used by the bank as an idempotency key.
+		///
+		/// Unlike the storage ranking — a rolling "current standing" that can
+		/// legitimately be paid any number of times — compute weights are a
+		/// *per-epoch entitlement*: `EpochWeights[epoch]` is written once and
+		/// never changes, so paying the same epoch twice pays the same work
+		/// twice. The bank refuses to settle an epoch it has already settled.
+		///
+		/// Return `None` if the source has no settlement period, which opts out
+		/// of the replay check entirely.
+		fn current_weight_epoch() -> Option<u64>;
 	}
 
 	/// Version 1 is "activated": requesters whitelisted and pre-upgrade backing
@@ -218,6 +231,15 @@ pub mod pallet {
 	/// `pay_compute_miners`.
 	#[pallet::storage]
 	pub type ComputeEmissionPaidOut<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+	/// Last compute epoch settled by `pay_compute_miners`, the idempotency key
+	/// that stops one epoch's weights being paid twice.
+	///
+	/// `OptionQuery`: `None` means nothing has ever been settled, which is
+	/// distinct from having settled epoch `0`. With `ValueQuery` those two
+	/// states collide and a genuine epoch-0 payout could be replayed.
+	#[pallet::storage]
+	pub type LastPaidComputeEpoch<T: Config> = StorageValue<_, u64, OptionQuery>;
 
 	/// Lifetime total released per requester (e.g. arion vs compute escrow).
 	#[pallet::storage]
@@ -348,6 +370,9 @@ pub mod pallet {
 		TooManyComputeMiners,
 		/// No compute miner carries a non-zero weight this window.
 		NoEligibleComputeMiners,
+		/// This compute epoch has already been settled. Re-paying it would
+		/// pay the same epoch's work twice; wait for the next epoch close.
+		ComputeEpochAlreadyPaid,
 	}
 
 	#[pallet::call]
@@ -606,6 +631,18 @@ pub mod pallet {
 			// consumer overdrew, or the ED cushion); never overdraw the account.
 			ensure!(amount <= Self::available_for_payout(), Error::<T>::InsufficientBankBalance);
 
+			// Replay guard. `EpochWeights[epoch]` is written once by the epoch
+			// close and never mutates, so re-running this call against the same
+			// epoch pays the same work a second time — a retried transaction
+			// (submitter didn't see the receipt) silently double-spends the
+			// compartment. Settle each epoch at most once, strictly forward.
+			let weight_epoch = T::ComputeMinerWeights::current_weight_epoch();
+			if let Some(epoch) = weight_epoch {
+				if let Some(last_paid) = LastPaidComputeEpoch::<T>::get() {
+					ensure!(epoch > last_paid, Error::<T>::ComputeEpochAlreadyPaid);
+				}
+			}
+
 			let miners = T::ComputeMinerWeights::active_compute_miners();
 			ensure!(
 				u32::try_from(miners.len()).unwrap_or(u32::MAX)
@@ -665,6 +702,18 @@ pub mod pallet {
 			ComputeEmissionPaidOut::<T>::mutate(|t| *t = t.saturating_add(paid));
 			TotalPaidOut::<T>::mutate(|t| *t = t.saturating_add(paid));
 			MinerPayoutPeriodAmount::<T>::mutate(|t| *t = t.saturating_add(paid));
+			// Advance the cursor only once something actually moved. A call
+			// where every transfer was skipped (e.g. all owners sat below their
+			// ED) paid nobody, and burning the epoch here would strand it
+			// permanently — the operator could never retry after fixing the
+			// cause. A PARTIAL payout does consume the epoch, matching the
+			// existing rule that skipped shares and floor-division dust stay in
+			// the compartment rather than being re-paid.
+			if !paid.is_zero() {
+				if let Some(epoch) = weight_epoch {
+					LastPaidComputeEpoch::<T>::put(epoch);
+				}
+			}
 			Self::deposit_event(Event::ComputeMinersPaid {
 				requested: amount,
 				paid,

--- a/pallets/hippocampus/src/mock.rs
+++ b/pallets/hippocampus/src/mock.rs
@@ -50,6 +50,7 @@ parameter_types! {
 
 thread_local! {
 	static RANKED_MINERS: RefCell<Vec<(AccountId, u16)>> = const { RefCell::new(Vec::new()) };
+	static COMPUTE_MINERS: RefCell<Vec<(AccountId, u128)>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Test control for the ranked-miner set `pay_storage_miners` reads.
@@ -62,10 +63,22 @@ pub fn whitelist_miner_payment_caller(who: AccountId) {
 	pallet_hippocampus::MinerPaymentWhitelist::<Test>::insert(who, ());
 }
 
+/// Test control for the weighted compute-miner set `pay_compute_miners` reads.
+pub fn set_compute_miners(miners: Vec<(AccountId, u128)>) {
+	COMPUTE_MINERS.with(|m| *m.borrow_mut() = miners);
+}
+
 pub struct MockRanking;
 impl pallet_hippocampus::StorageMinerRanking<AccountId> for MockRanking {
 	fn active_storage_miners() -> Vec<(AccountId, u16)> {
 		RANKED_MINERS.with(|m| m.borrow().clone())
+	}
+}
+
+pub struct MockComputeWeights;
+impl pallet_hippocampus::ComputeMinerWeights<AccountId> for MockComputeWeights {
+	fn active_compute_miners() -> Vec<(AccountId, u128)> {
+		COMPUTE_MINERS.with(|m| m.borrow().clone())
 	}
 }
 
@@ -85,6 +98,8 @@ impl pallet_hippocampus::Config for Test {
 	type MaxMinersPerPayout = ConstU32<16>;
 	type BlocksPer24Hours = BlocksPer24Hours;
 	type Max24HourMinerPayout = Max24HourMinerPayout;
+	type ComputeMinerWeights = MockComputeWeights;
+	type MaxComputeMinersPerPayout = ConstU32<16>;
 	type WeightInfo = ();
 }
 
@@ -120,6 +135,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext.execute_with(|| {
 		System::set_block_number(1);
 		set_ranked_miners(Vec::new());
+		set_compute_miners(Vec::new());
 	});
 	ext
 }

--- a/pallets/hippocampus/src/mock.rs
+++ b/pallets/hippocampus/src/mock.rs
@@ -51,6 +51,10 @@ parameter_types! {
 thread_local! {
 	static RANKED_MINERS: RefCell<Vec<(AccountId, u16)>> = const { RefCell::new(Vec::new()) };
 	static COMPUTE_MINERS: RefCell<Vec<(AccountId, u128)>> = const { RefCell::new(Vec::new()) };
+	/// Epoch the mock weight set belongs to. Defaults to `None` so the tests
+	/// that predate the replay guard keep exercising a source with no
+	/// settlement period, and only the tests that opt in drive the cursor.
+	static COMPUTE_EPOCH: RefCell<Option<u64>> = const { RefCell::new(None) };
 }
 
 /// Test control for the ranked-miner set `pay_storage_miners` reads.
@@ -75,10 +79,20 @@ impl pallet_hippocampus::StorageMinerRanking<AccountId> for MockRanking {
 	}
 }
 
+/// Test control for the epoch the compute weight set belongs to. `None`
+/// (the default) opts out of the bank's replay guard.
+pub fn set_compute_epoch(epoch: Option<u64>) {
+	COMPUTE_EPOCH.with(|e| *e.borrow_mut() = epoch);
+}
+
 pub struct MockComputeWeights;
 impl pallet_hippocampus::ComputeMinerWeights<AccountId> for MockComputeWeights {
 	fn active_compute_miners() -> Vec<(AccountId, u128)> {
 		COMPUTE_MINERS.with(|m| m.borrow().clone())
+	}
+
+	fn current_weight_epoch() -> Option<u64> {
+		COMPUTE_EPOCH.with(|e| *e.borrow())
 	}
 }
 

--- a/pallets/hippocampus/src/tests.rs
+++ b/pallets/hippocampus/src/tests.rs
@@ -1371,3 +1371,56 @@ fn a_source_without_an_epoch_is_not_replay_guarded() {
 		assert_eq!(Balances::free_balance(charlie()), 1_000);
 	});
 }
+
+#[test]
+fn request_payment_cannot_spend_the_emission_compartments() {
+	// The compartments are reserved for the two miner payouts. A whitelisted
+	// requester could previously drain the bank down to ED while the ledger
+	// still showed a full compartment, leaving `pay_compute_miners` to fail
+	// with `InsufficientBankBalance` against emission reserved for it.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 1_000, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			5_000,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			3_000,
+			DepositType::ComputeEmission
+		));
+		assert_ok!(Hippocampus::add_requester(RuntimeOrigin::root(), bob()));
+
+		// 9_000 in the bank, but 8_000 of it is spoken for.
+		let unreserved = Hippocampus::unreserved_for_payout();
+		let paid = Hippocampus::request_payment(&bob(), &charlie(), 9_000).expect("pays");
+
+		assert_eq!(paid, unreserved, "only the unreserved remainder is spendable");
+		assert!(paid <= 1_000, "the grant, not the emission, is what was available");
+		// Both compartments survive intact and are still fully payable.
+		assert_eq!(Hippocampus::emission_available(), 5_000);
+		assert_eq!(Hippocampus::compute_emission_available(), 3_000);
+
+		set_compute_miners(vec![(dave(), 1)]);
+		whitelist_miner_payment_caller(alice());
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 3_000));
+		assert_eq!(Balances::free_balance(dave()), 3_000);
+	});
+}
+
+#[test]
+fn request_payment_still_spends_freely_when_nothing_is_reserved() {
+	// The clamp must not starve the ordinary path — with empty compartments,
+	// the full balance above ED remains spendable.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 5_000, DepositType::Grant));
+		assert_ok!(Hippocampus::add_requester(RuntimeOrigin::root(), bob()));
+
+		assert_eq!(Hippocampus::unreserved_for_payout(), Hippocampus::available_for_payout());
+		// `available_for_payout` is free-minus-ED, so the ED cushion — and only
+		// the ED cushion — is withheld.
+		let paid = Hippocampus::request_payment(&bob(), &charlie(), 5_000).expect("pays");
+		assert_eq!(paid, 5_000 - ExistentialDeposit::get());
+	});
+}

--- a/pallets/hippocampus/src/tests.rs
+++ b/pallets/hippocampus/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-	mock::*, ComputeEmissionPaidOut, DepositType, EmissionPaidOut, Error, Event,
+	mock::*, ComputeEmissionPaidOut, DepositType, EmissionPaidOut, Error, Event, LastPaidComputeEpoch,
 	MinerPaymentWhitelist, TotalDeposited, TotalPaidByRequester, TotalPaidOut,
 };
 use frame_support::{assert_noop, assert_ok};
@@ -1284,5 +1284,90 @@ fn removed_miner_payment_caller_cannot_pay_compute_miners() {
 			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(caller), 100),
 			Error::<Test>::PaymentCallerNotWhitelisted
 		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_refuses_to_settle_an_epoch_twice() {
+	// The replay guard keys on the weight source's epoch. A source that reports
+	// one keeps its epoch settleable exactly once.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		set_compute_epoch(Some(4));
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 500));
+		assert_eq!(LastPaidComputeEpoch::<Test>::get(), Some(4));
+
+		// Compartment still holds 500, so only the guard can reject this.
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 500),
+			Error::<Test>::ComputeEpochAlreadyPaid
+		);
+		// An older epoch is refused too — settlement only moves forward.
+		set_compute_epoch(Some(3));
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 500),
+			Error::<Test>::ComputeEpochAlreadyPaid
+		);
+
+		set_compute_epoch(Some(5));
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 500));
+		assert_eq!(LastPaidComputeEpoch::<Test>::get(), Some(5));
+		assert_eq!(Balances::free_balance(charlie()), 1_000);
+	});
+}
+
+#[test]
+fn a_payout_that_paid_nobody_leaves_the_epoch_settleable() {
+	// Every transfer skipped => nothing moved => burning the epoch would strand
+	// it forever. The cursor must not advance until something is actually paid.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		// Weight so small its share floors to zero => skipped, nothing paid.
+		set_compute_miners(vec![(charlie(), 1), (dave(), u64::MAX as u128)]);
+		set_compute_epoch(Some(7));
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1));
+		assert_eq!(Balances::free_balance(charlie()), 0, "share floored to zero");
+		assert_eq!(LastPaidComputeEpoch::<Test>::get(), None, "nothing paid, epoch not consumed");
+
+		// The same epoch can still be settled once the amount is workable.
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 999));
+		assert_eq!(LastPaidComputeEpoch::<Test>::get(), Some(7));
+	});
+}
+
+#[test]
+fn a_source_without_an_epoch_is_not_replay_guarded() {
+	// `current_weight_epoch() == None` opts out entirely, preserving the
+	// storage-ranking style semantics for any such source.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		set_compute_epoch(None);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 500));
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 500));
+		assert_eq!(LastPaidComputeEpoch::<Test>::get(), None);
+		assert_eq!(Balances::free_balance(charlie()), 1_000);
 	});
 }

--- a/pallets/hippocampus/src/tests.rs
+++ b/pallets/hippocampus/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-	mock::*, DepositType, EmissionPaidOut, Error, Event, MinerPaymentWhitelist, TotalDeposited,
-	TotalPaidByRequester, TotalPaidOut,
+	mock::*, ComputeEmissionPaidOut, DepositType, EmissionPaidOut, Error, Event,
+	MinerPaymentWhitelist, TotalDeposited, TotalPaidByRequester, TotalPaidOut,
 };
 use frame_support::{assert_noop, assert_ok};
 
@@ -691,5 +691,598 @@ fn pay_storage_miners_resets_24hour_period() {
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), cap));
 		assert_eq!(Hippocampus::emission_available(), 0);
 		assert_eq!(Balances::free_balance(charlie()), cap * 2);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// pay_compute_miners
+//
+// Mirrors the `pay_storage_miners` suite above, plus the tests that pin the
+// wall between the two compartments — the property that makes this a separate
+// extrinsic rather than a flag on the existing one.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pay_compute_miners_distributes_pro_rata() {
+	new_test_ext().execute_with(|| {
+		// The Grant covers the bank's ED so the full amount is payable.
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1), (dave(), 3)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1_000));
+
+		assert_eq!(Balances::free_balance(charlie()), 250);
+		assert_eq!(Balances::free_balance(dave()), 750);
+		assert_eq!(ComputeEmissionPaidOut::<Test>::get(), 1_000);
+		assert_eq!(Hippocampus::compute_emission_available(), 0);
+		assert_eq!(TotalPaidOut::<Test>::get(), 1_000);
+		System::assert_last_event(
+			Event::ComputeMinersPaid {
+				requested: 1_000,
+				paid: 1_000,
+				miners_paid: 2,
+				miners_skipped: 0,
+			}
+			.into(),
+		);
+
+		let events = System::events();
+		for expected in [
+			Event::ComputeMinerPaymentPaid { miner: charlie(), amount: 250 },
+			Event::ComputeMinerPaymentPaid { miner: dave(), amount: 750 },
+		] {
+			let expected = expected.into();
+			assert!(
+				events.iter().any(|record| record.event == expected),
+				"missing per-miner event: {expected:?}"
+			);
+		}
+	});
+}
+
+#[test]
+fn pay_compute_miners_handles_wide_u128_weights() {
+	// The compute weights are u128, not the storage ranking's u16 — a realistic
+	// `EpochWeights` pair near `MaxEpochWeightPerNode` (u64::MAX) must still
+	// split cleanly and never overflow the wide intermediate.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::ComputeEmission
+		));
+		let big = u64::MAX as u128;
+		set_compute_miners(vec![(charlie(), big), (dave(), big)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 10_000));
+
+		assert_eq!(Balances::free_balance(charlie()), 5_000);
+		assert_eq!(Balances::free_balance(dave()), 5_000);
+		assert_eq!(ComputeEmissionPaidOut::<Test>::get(), 10_000);
+	});
+}
+
+#[test]
+fn pay_compute_miners_conserves_every_planck() {
+	// Invariant sweep: whatever the weight vector, exactly `paid` leaves the
+	// bank, all of it lands with miners, both ledgers book the same figure,
+	// and floor-division dust is bounded by one planck per miner.
+	let cases: &[(&[u128], u128)] = &[
+		(&[1, 3], 1_000),
+		(&[7, 7, 7], 1_000),
+		(&[1, u32::MAX as u128], 9_999),
+		(&[13, 29, 58], 101),
+		(&[5], 10),
+		(&[1, 2, 3, 4, 5, 6, 7], 9_973),
+	];
+	for (weights, amount) in cases {
+		new_test_ext().execute_with(|| {
+			assert_ok!(Hippocampus::deposit(
+				RuntimeOrigin::signed(alice()),
+				10,
+				DepositType::Grant
+			));
+			assert_ok!(Hippocampus::deposit(
+				RuntimeOrigin::signed(alice()),
+				10_000,
+				DepositType::ComputeEmission
+			));
+			let miners: Vec<(AccountId, u128)> = weights
+				.iter()
+				.enumerate()
+				.map(|(i, w)| {
+					let index = u8::try_from(i).expect("small test vector");
+					(sp_runtime::AccountId32::new([100 + index; 32]), *w)
+				})
+				.collect();
+			set_compute_miners(miners.clone());
+			whitelist_miner_payment_caller(alice());
+
+			let bank_before = Balances::free_balance(hippocampus_account());
+			assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), *amount));
+
+			let received: u128 =
+				miners.iter().map(|(miner, _)| Balances::free_balance(miner)).sum();
+			let bank_delta = bank_before - Balances::free_balance(hippocampus_account());
+			assert_eq!(received, bank_delta, "weights {weights:?}");
+			assert_eq!(ComputeEmissionPaidOut::<Test>::get(), received, "weights {weights:?}");
+			assert_eq!(TotalPaidOut::<Test>::get(), received, "weights {weights:?}");
+			assert!(received <= *amount);
+			assert!(
+				*amount - received < weights.len() as u128,
+				"dust exceeded bound for weights {weights:?}: paid {received} of {amount}"
+			);
+		});
+	}
+}
+
+#[test]
+fn pay_compute_miners_skips_failed_transfers() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		// charlie's share (101 * 1/20 = 5) is below the ED of 10 and charlie
+		// holds no account, so the transfer itself fails and is skipped;
+		// dave's share (95) clears the ED and pays out.
+		set_compute_miners(vec![(charlie(), 1), (dave(), 19)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 101));
+
+		assert_eq!(Balances::free_balance(charlie()), 0);
+		assert_eq!(Balances::free_balance(dave()), 95);
+		assert_eq!(ComputeEmissionPaidOut::<Test>::get(), 95);
+		assert_eq!(Hippocampus::compute_emission_available(), 905);
+		System::assert_last_event(
+			Event::ComputeMinersPaid {
+				requested: 101,
+				paid: 95,
+				miners_paid: 1,
+				miners_skipped: 1,
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_dust_stays_in_compartment() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 3), (dave(), 7)]);
+		whitelist_miner_payment_caller(alice());
+
+		// 101 * 3/10 = 30, 101 * 7/10 = 70 — one planck of dust remains.
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 101));
+
+		assert_eq!(Balances::free_balance(charlie()), 30);
+		assert_eq!(Balances::free_balance(dave()), 70);
+		assert_eq!(ComputeEmissionPaidOut::<Test>::get(), 100);
+		assert_eq!(Hippocampus::compute_emission_available(), 900);
+	});
+}
+
+#[test]
+fn pay_compute_miners_skips_zero_shares() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			100_000,
+			DepositType::ComputeEmission
+		));
+		// 10_000 * 1/65_536 floors to zero: charlie is skipped, not fatal.
+		set_compute_miners(vec![(charlie(), 1), (dave(), 65_535)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 10_000));
+
+		assert_eq!(Balances::free_balance(charlie()), 0);
+		assert_eq!(Balances::free_balance(dave()), 9_999);
+		System::assert_last_event(
+			Event::ComputeMinersPaid {
+				requested: 10_000,
+				paid: 9_999,
+				miners_paid: 1,
+				miners_skipped: 1,
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_requires_whitelisted_caller() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::PaymentCallerNotWhitelisted
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_rejects_zero_amount() {
+	new_test_ext().execute_with(|| {
+		whitelist_miner_payment_caller(alice());
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 0),
+			Error::<Test>::ZeroAmount
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_respects_distribution_switch() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		whitelist_miner_payment_caller(alice());
+		assert_ok!(Hippocampus::set_distribution_enabled(RuntimeOrigin::root(), false));
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::DistributionDisabled
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_cannot_spend_other_compartments() {
+	new_test_ext().execute_with(|| {
+		// A fat bank funded by everything except compute emission — including
+		// the *storage* emission compartment — pays nothing.
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 1_000, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::MarketplaceRevenue
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		whitelist_miner_payment_caller(alice());
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::InsufficientComputeEmissionFunds
+		);
+	});
+}
+
+#[test]
+fn pay_storage_miners_cannot_spend_the_compute_compartment() {
+	// The other direction of the wall: compute emission is invisible to the
+	// storage payout.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 1_000, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_ranked_miners(vec![(charlie(), 1)]);
+		whitelist_miner_payment_caller(alice());
+		assert_noop!(
+			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::InsufficientEmissionFunds
+		);
+	});
+}
+
+#[test]
+fn the_two_compartments_are_independently_spendable() {
+	// Both funded, both fully spent — neither ledger nor 24h counter bleeds
+	// into the other.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_ranked_miners(vec![(charlie(), 1)]);
+		set_compute_miners(vec![(dave(), 1)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 1_000));
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1_000));
+
+		assert_eq!(Balances::free_balance(charlie()), 1_000);
+		assert_eq!(Balances::free_balance(dave()), 1_000);
+		assert_eq!(EmissionPaidOut::<Test>::get(), 1_000);
+		assert_eq!(ComputeEmissionPaidOut::<Test>::get(), 1_000);
+		assert_eq!(Hippocampus::emission_available(), 0);
+		assert_eq!(Hippocampus::compute_emission_available(), 0);
+		assert_eq!(TotalPaidOut::<Test>::get(), 2_000);
+	});
+}
+
+#[test]
+fn pay_compute_miners_cannot_overdraw_the_bank() {
+	new_test_ext().execute_with(|| {
+		// Compartment says 1_000 but another consumer already drained the
+		// account below that — reject rather than pay partially.
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		assert_ok!(Hippocampus::add_requester(RuntimeOrigin::root(), bob()));
+		assert_ok!(Hippocampus::request_payment(&bob(), &charlie(), 600));
+		set_compute_miners(vec![(dave(), 1)]);
+		whitelist_miner_payment_caller(alice());
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1_000),
+			Error::<Test>::InsufficientBankBalance
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_rejects_empty_or_zero_weight_set() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		whitelist_miner_payment_caller(alice());
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::NoEligibleComputeMiners
+		);
+		// Every node reported by the validator as a zero-reward verdict.
+		set_compute_miners(vec![(charlie(), 0), (dave(), 0)]);
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::NoEligibleComputeMiners
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_bounds_the_miner_list() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		// MaxComputeMinersPerPayout is 16 in the mock; 17 entries must reject.
+		let miners: Vec<_> =
+			(1u8..=17).map(|i| (sp_runtime::AccountId32::new([i; 32]), 1u128)).collect();
+		set_compute_miners(miners);
+		whitelist_miner_payment_caller(alice());
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100),
+			Error::<Test>::TooManyComputeMiners
+		);
+	});
+}
+
+#[test]
+fn pay_compute_miners_compartment_is_cumulative() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			1_000,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 600));
+		assert_eq!(Hippocampus::compute_emission_available(), 400);
+
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 401),
+			Error::<Test>::InsufficientComputeEmissionFunds
+		);
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 400));
+		assert_eq!(Hippocampus::compute_emission_available(), 0);
+		assert_eq!(Balances::free_balance(charlie()), 1_000);
+	});
+}
+
+#[test]
+fn pay_compute_miners_respects_24hour_cap() {
+	new_test_ext().execute_with(|| {
+		let cap = Max24HourMinerPayout::get();
+
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			cap * 2,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), cap + 1),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), cap - 100));
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 101),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 100));
+		assert_eq!(Balances::free_balance(charlie()), cap);
+	});
+}
+
+#[test]
+fn the_24hour_budget_is_shared_across_both_payouts() {
+	// One `Max24HourMinerPayout` for storage and compute together: whatever
+	// one payout spends is gone from the other's daily allowance, even though
+	// each still has its own fully-funded compartment.
+	new_test_ext().execute_with(|| {
+		let cap = Max24HourMinerPayout::get();
+
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			cap,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			cap,
+			DepositType::ComputeEmission
+		));
+		set_ranked_miners(vec![(charlie(), 1)]);
+		set_compute_miners(vec![(dave(), 1)]);
+		whitelist_miner_payment_caller(alice());
+
+		// Storage takes 60% of the shared daily budget.
+		let storage_spend = cap / 10 * 6;
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), storage_spend));
+
+		// Compute may spend only the remainder, however full its compartment is.
+		assert_noop!(
+			Hippocampus::pay_compute_miners(
+				RuntimeOrigin::signed(alice()),
+				cap - storage_spend + 1
+			),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+		assert_ok!(Hippocampus::pay_compute_miners(
+			RuntimeOrigin::signed(alice()),
+			cap - storage_spend
+		));
+
+		// The shared budget is now exhausted for BOTH payouts.
+		assert_noop!(
+			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 1),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+
+		assert_eq!(Balances::free_balance(charlie()) + Balances::free_balance(dave()), cap);
+		// Both compartments still hold what the rate limit stopped them spending.
+		assert_eq!(Hippocampus::emission_available(), cap - storage_spend);
+		assert_eq!(Hippocampus::compute_emission_available(), storage_spend);
+	});
+}
+
+#[test]
+fn the_shared_24hour_period_resets_once_for_both_payouts() {
+	new_test_ext().execute_with(|| {
+		let cap = Max24HourMinerPayout::get();
+
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			cap,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			cap,
+			DepositType::ComputeEmission
+		));
+		set_ranked_miners(vec![(charlie(), 1)]);
+		set_compute_miners(vec![(dave(), 1)]);
+		whitelist_miner_payment_caller(alice());
+
+		// Compute exhausts the shared budget; storage is locked out too.
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), cap));
+		assert_noop!(
+			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 1),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+
+		// Crossing the boundary resets the one counter, so storage — which
+		// never spent a planck this period — can now draw a full budget.
+		System::set_block_number(BlocksPer24Hours::get());
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), cap));
+		assert_eq!(Balances::free_balance(charlie()), cap);
+		assert_eq!(Balances::free_balance(dave()), cap);
+	});
+}
+
+#[test]
+fn pay_compute_miners_resets_24hour_period() {
+	new_test_ext().execute_with(|| {
+		let cap = Max24HourMinerPayout::get();
+
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			cap * 2,
+			DepositType::ComputeEmission
+		));
+		set_compute_miners(vec![(charlie(), 1)]);
+		whitelist_miner_payment_caller(alice());
+
+		// Exhaust the whole 24-hour budget; the next planck rejects.
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), cap));
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+
+		// One block short of the period boundary the budget is still spent.
+		System::set_block_number(BlocksPer24Hours::get() - 1);
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 1),
+			Error::<Test>::ExceedsDaily24HourMinerPayoutLimit
+		);
+
+		// At the boundary the period resets and a full budget is available.
+		System::set_block_number(BlocksPer24Hours::get());
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), cap));
+		assert_eq!(Hippocampus::compute_emission_available(), 0);
+		assert_eq!(Balances::free_balance(charlie()), cap * 2);
+	});
+}
+
+#[test]
+fn removed_miner_payment_caller_cannot_pay_compute_miners() {
+	new_test_ext().execute_with(|| {
+		let caller = alice();
+		assert_ok!(Hippocampus::add_miner_payment_caller(RuntimeOrigin::root(), caller.clone()));
+		assert_ok!(Hippocampus::remove_miner_payment_caller(RuntimeOrigin::root(), caller.clone()));
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(caller), 100),
+			Error::<Test>::PaymentCallerNotWhitelisted
+		);
 	});
 }

--- a/pallets/hippocampus/src/weights.rs
+++ b/pallets/hippocampus/src/weights.rs
@@ -17,6 +17,7 @@ pub trait WeightInfo {
 	fn add_requester() -> Weight;
 	fn remove_requester() -> Weight;
 	fn pay_storage_miners(n: u32) -> Weight;
+	fn pay_compute_miners(n: u32) -> Weight;
 }
 
 /// Weights using runtime `DbWeight`.
@@ -53,6 +54,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 					.saturating_mul(n.into()),
 			)
 	}
+
+	fn pay_compute_miners(n: u32) -> Weight {
+		// Same shape as `pay_storage_miners`: guards + compute-compartment
+		// bookkeeping, then one transfer (2 account reads/writes) per miner.
+		Weight::from_parts(30_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+			.saturating_add(
+				Weight::from_parts(50_000_000, 0)
+					.saturating_add(T::DbWeight::get().reads_writes(2, 2))
+					.saturating_mul(n.into()),
+			)
+	}
 }
 
 impl WeightInfo for () {
@@ -75,6 +89,17 @@ impl WeightInfo for () {
 	}
 
 	fn pay_storage_miners(n: u32) -> Weight {
+		Weight::from_parts(30_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(5_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(
+				Weight::from_parts(50_000_000, 0)
+					.saturating_add(RocksDbWeight::get().reads_writes(2, 2))
+					.saturating_mul(n.into()),
+			)
+	}
+
+	fn pay_compute_miners(n: u32) -> Weight {
 		Weight::from_parts(30_000_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -1344,7 +1344,8 @@ pub mod pallet {
 			// still owed to the ranking/marketplace pots and chargeback
 			// refunds still owed to the sudo account are not spendable as
 			// commissions, the root-set ReferralBankFloor, and the emission
-			// compartment reserved for ranking-based `pay_storage_miners` stay
+			// compartments reserved for ranking-based `pay_storage_miners` and
+			// weight-based `pay_compute_miners` stay
 			// untouched on top of that. Commission volume can at worst
 			// drain the headroom above the floor, never funds owed to
 			// someone else and never the last of the bank.
@@ -1353,6 +1354,10 @@ pub mod pallet {
 				.saturating_add(ReferralBankFloor::<T>::get())
 				.saturating_add(
 					pallet_hippocampus::Pallet::<T>::emission_available().saturated_into::<u128>(),
+				)
+				.saturating_add(
+					pallet_hippocampus::Pallet::<T>::compute_emission_available()
+						.saturated_into::<u128>(),
 				);
 			let headroom = pallet_hippocampus::Pallet::<T>::available_for_payout()
 				.saturated_into::<u128>()

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -150,14 +150,16 @@ impl pallet_arion::PayoutSource<AccountId, Balance> for ArionPayoutSource {
 	fn available() -> Balance {
 		// Compartmentalization: the alpha backing still owed to the ranking /
 		// marketplace pots — and chargeback refunds still owed back to the
-		// sudo account — and the emission compartment reserved for ranking-based
-		// `pay_storage_miners` — is not spendable by the miner settlement: a runaway
+		// sudo account — and the emission compartments reserved for ranking-based
+		// `pay_storage_miners` and weight-based `pay_compute_miners` — is not
+		// spendable by the miner settlement: a runaway
 		// miner due (bad stats, bad price, compromised authority key) can at
 		// worst drain the miner budget, never funds owed to someone else.
 		pallet_hippocampus::Pallet::<Runtime>::available_for_payout()
 			.saturating_sub(pallet_marketplace::TotalUndistributedBacking::<Runtime>::get())
 			.saturating_sub(pallet_marketplace::PendingSudoRefunds::<Runtime>::get())
 			.saturating_sub(pallet_hippocampus::Pallet::<Runtime>::emission_available())
+			.saturating_sub(pallet_hippocampus::Pallet::<Runtime>::compute_emission_available())
 	}
 }
 
@@ -189,6 +191,59 @@ impl pallet_hippocampus::StorageMinerRanking<AccountId> for StorageMinerRankingS
 				}
 			})
 			.collect()
+	}
+}
+
+/// Adapter: `pay_compute_miners` reads the compute-scoring pallet's §23
+/// reward weights for the most recently closed epoch and pays each node's
+/// **family** account (the operator that put up the child deposit).
+///
+/// `CurrentEpoch` holds the epoch id of the last `vali_submit_epoch_close`
+/// (the close writes `EpochWeights[epoch][*]` and then sets `CurrentEpoch =
+/// epoch`), so it *is* the last closed epoch — not `epoch - 1`. Before the
+/// first close it is `0` and the weight map is empty, which the bank rejects
+/// with `NoEligibleComputeMiners`.
+///
+/// No status filter is applied on top of the weights: the validator already
+/// encodes its verdict in the weight itself (a Quarantined node is reported
+/// as `Some(0)`), and a node the validator did not report at all has no
+/// `EpochWeights` entry. Nodes whose child registration has since gone
+/// `Unbonding`, or whose `node_id` no longer maps to a child, are dropped —
+/// they are no longer operating.
+///
+/// Weights of every child belonging to the same family are summed so a family
+/// receives one transfer and consumes one `MaxComputeMinersPerPayout` slot,
+/// however many nodes it runs.
+pub struct ComputeMinerWeightsSource;
+impl pallet_hippocampus::ComputeMinerWeights<AccountId> for ComputeMinerWeightsSource {
+	fn active_compute_miners() -> Vec<(AccountId, u128)> {
+		use sp_std::collections::btree_map::BTreeMap;
+
+		let epoch = pallet_compute_scoring::CurrentEpoch::<Runtime>::get();
+
+		let mut by_family: BTreeMap<AccountId, u128> = BTreeMap::new();
+		for entry in pallet_compute_scoring::Pallet::<Runtime>::epoch_weights_for(epoch) {
+			if entry.weight == 0 {
+				continue;
+			}
+			let Some(child) = pallet_compute_scoring::NodeIdToChild::<Runtime>::get(entry.node_id)
+			else {
+				continue;
+			};
+			let Some(reg) = pallet_compute_scoring::ChildRegistrations::<Runtime>::get(&child)
+			else {
+				continue;
+			};
+			if reg.status != pallet_compute_scoring::ChildStatus::Active {
+				continue;
+			}
+			by_family
+				.entry(reg.family)
+				.and_modify(|w| *w = w.saturating_add(entry.weight))
+				.or_insert(entry.weight);
+		}
+
+		by_family.into_iter().collect()
 	}
 }
 
@@ -368,6 +423,9 @@ parameter_types! {
 	/// Miner payment settlement interval (~24h at 6s/block). `0` = disabled.
 	pub const ArionSettlementInterval: BlockNumber = 14_400;
 	pub const BlocksPer24Hours: BlockNumber = 14_400; // ~24 hours at 6-second blocks
+	/// Total emission the bank may release to miners per 24 hours, across
+	/// `pay_storage_miners` AND `pay_compute_miners` together — one shared
+	/// counter, not one each.
 	pub const Max24HourMinerPayout: Balance = 3_500_000_000_000_000_000_000; // 3500 alpha (18 decimals)
 }
 
@@ -380,6 +438,10 @@ impl pallet_hippocampus::Config for Runtime {
 	type MaxMinersPerPayout = ConstU32<512>;
 	type BlocksPer24Hours = BlocksPer24Hours;
 	type Max24HourMinerPayout = Max24HourMinerPayout;
+	type ComputeMinerWeights = ComputeMinerWeightsSource;
+	// Payees are families, not nodes: `pallet_compute_scoring::MaxFamilies`
+	// (600) bounds the list regardless of how many children each one runs.
+	type MaxComputeMinersPerPayout = ConstU32<640>;
 	type WeightInfo = pallet_hippocampus::weights::SubstrateWeight<Runtime>;
 }
 #[cfg(feature = "std")]
@@ -468,7 +530,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92005,
+	// 92006: `hippocampus.pay_compute_miners` (call index 8 → 9) plus the
+	// `DepositType::ComputeEmission` compartment and its `ComputeEmissionPaidOut`
+	// ledger.
+	spec_version: 92006,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -439,8 +439,12 @@ impl pallet_hippocampus::Config for Runtime {
 	type BlocksPer24Hours = BlocksPer24Hours;
 	type Max24HourMinerPayout = Max24HourMinerPayout;
 	type ComputeMinerWeights = ComputeMinerWeightsSource;
-	// Payees are families, not nodes: `pallet_compute_scoring::MaxFamilies`
-	// (600) bounds the list regardless of how many children each one runs.
+	// Payees are families, not nodes. The bound comes from
+	// `pallet_compute_scoring::MaxMinerStatusUpdatesPerCall` (128): one close
+	// per epoch writes at most that many `EpochWeights` entries, which
+	// aggregate to at most that many distinct families. Keep this ABOVE
+	// `MaxMinerStatusUpdatesPerCall` — if that constant ever exceeds this one,
+	// every `pay_compute_miners` call fails with `TooManyComputeMiners`.
 	type MaxComputeMinersPerPayout = ConstU32<640>;
 	type WeightInfo = pallet_hippocampus::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -204,12 +204,28 @@ impl pallet_hippocampus::StorageMinerRanking<AccountId> for StorageMinerRankingS
 /// first close it is `0` and the weight map is empty, which the bank rejects
 /// with `NoEligibleComputeMiners`.
 ///
-/// No status filter is applied on top of the weights: the validator already
-/// encodes its verdict in the weight itself (a Quarantined node is reported
-/// as `Some(0)`), and a node the validator did not report at all has no
-/// `EpochWeights` entry. Nodes whose child registration has since gone
-/// `Unbonding`, or whose `node_id` no longer maps to a child, are dropped —
-/// they are no longer operating.
+/// TWO status fields are checked, because compute-scoring keeps two and they
+/// move independently:
+///
+/// * `ChildRegistrations[child].status` (`ChildStatus`) is the *registration*
+///   lifecycle — `Unbonding`, or a `node_id` that no longer maps to a child,
+///   means the operator is gone.
+/// * `MinerStatuses[node_id]` (`MinerStatus`) is the *operational* verdict —
+///   `Quarantined` / `Decommissioned`.
+///
+/// Filtering on the registration alone is not enough. `request_unstake`
+/// quarantines every child of an exiting family via `transition_node_status`
+/// but leaves `ChildStatus::Active` untouched, so a family that pulled its
+/// entire collateral *after* an epoch closed would otherwise still collect its
+/// full pro-rata share of that epoch's stale weights with nothing at risk —
+/// the opposite of compute-scoring's "a stranded reward is not a stranded
+/// fund" intent. The weight alone cannot be relied on to encode the verdict:
+/// `vali_submit_epoch_close` always writes the submitted weight and transitions
+/// status separately, so a batch entry may carry `Quarantined` *and* a non-zero
+/// weight.
+///
+/// `MinerStatuses` is `OptionQuery` and a node recovering to `Active` has its
+/// row REMOVED, so an absent row means Active and must NOT be filtered out.
 ///
 /// Weights of every child belonging to the same family are summed so a family
 /// receives one transfer and consumes one `MaxComputeMinersPerPayout` slot,
@@ -237,6 +253,13 @@ impl pallet_hippocampus::ComputeMinerWeights<AccountId> for ComputeMinerWeightsS
 			if reg.status != pallet_compute_scoring::ChildStatus::Active {
 				continue;
 			}
+			// Absent row == Active (see above); only an explicit non-Active
+			// operational status is disqualifying.
+			if let Some(op) = pallet_compute_scoring::MinerStatuses::<Runtime>::get(entry.node_id) {
+				if op.status != pallet_compute_scoring::MinerStatus::Active {
+					continue;
+				}
+			}
 			by_family
 				.entry(reg.family)
 				.and_modify(|w| *w = w.saturating_add(entry.weight))
@@ -244,6 +267,12 @@ impl pallet_hippocampus::ComputeMinerWeights<AccountId> for ComputeMinerWeightsS
 		}
 
 		by_family.into_iter().collect()
+	}
+
+	fn current_weight_epoch() -> Option<u64> {
+		// Same value `active_compute_miners` reads its weights from, so the
+		// bank's replay guard keys on exactly the epoch it is settling.
+		Some(pallet_compute_scoring::CurrentEpoch::<Runtime>::get())
 	}
 }
 
@@ -426,6 +455,19 @@ parameter_types! {
 	/// Total emission the bank may release to miners per 24 hours, across
 	/// `pay_storage_miners` AND `pay_compute_miners` together — one shared
 	/// counter, not one each.
+	///
+	/// 3500 is deliberately the COMBINED ceiling, not a per-payout allowance,
+	/// and is NOT to be scaled up because a second consumer was added. The two
+	/// payouts compete for one daily budget by design: whatever storage draws
+	/// is unavailable to compute for the rest of the period, and vice versa.
+	/// A day where storage draws heavily and compute then hits
+	/// `ExceedsDaily24HourMinerPayoutLimit` is the cap working as intended —
+	/// no funds are lost, the compute compartment is cumulative and the
+	/// remainder settles in a later period.
+	///
+	/// Do not "fix" that contention by raising this to cover both consumers
+	/// separately; sizing it against the sum of both emission schedules would
+	/// double the maximum daily drain this constant exists to bound.
 	pub const Max24HourMinerPayout: Balance = 3_500_000_000_000_000_000_000; // 3500 alpha (18 decimals)
 }
 
@@ -534,14 +576,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	// 92006: `hippocampus.pay_compute_miners` (call index 8 → 9) plus the
-	// `DepositType::ComputeEmission` compartment and its `ComputeEmissionPaidOut`
-	// ledger.
 	spec_version: 92006,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
-	// Bumped with 9196: `arion.register_child` dropped its `miner_uid`
-	// argument, so previously-encoded calls no longer decode.
 	transaction_version: 1,
 	state_version: 0,
 };

--- a/runtime/mainnet/tests/pay_compute_miners.rs
+++ b/runtime/mainnet/tests/pay_compute_miners.rs
@@ -62,6 +62,110 @@ fn seed_compute_child(
 	pallet_compute_scoring::EpochWeights::<Runtime>::insert(epoch, node_id, weight);
 }
 
+/// Set the *operational* status of a seeded node — the `MinerStatuses` row
+/// that `request_unstake` and `vali_submit_epoch_close` transition, which is
+/// independent of the `ChildStatus` in the registration.
+fn set_operational_status(node_seed: u8, status: pallet_compute_scoring::MinerStatus) {
+	pallet_compute_scoring::MinerStatuses::<Runtime>::insert(
+		[node_seed; 32],
+		pallet_compute_scoring::MinerStatusEntry {
+			status,
+			last_transition_block: 0u32.into(),
+			last_transition_epoch: 0u64,
+		},
+	);
+}
+
+#[test]
+fn a_quarantined_node_is_not_paid_even_while_its_registration_is_active() {
+	// `request_unstake` quarantines every child of an exiting family but leaves
+	// `ChildStatus::Active` alone, so a family that pulled its whole collateral
+	// after the epoch closed would still hold a live registration against a
+	// stale weight. Paying it would hand out rewards with nothing at risk.
+	new_test_ext().execute_with(|| {
+		let (honest, exiting) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_compute_child(10, &honest, &account(20), 7, 100, ChildStatus::Active);
+		seed_compute_child(11, &exiting, &account(21), 7, 100, ChildStatus::Active);
+		// Registration still Active — only the operational status moved.
+		set_operational_status(11, pallet_compute_scoring::MinerStatus::Quarantined);
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		// Equal weights, so a missed filter would split 50/50 and pay 50_000.
+		assert_eq!(Balances::free_balance(&honest), 100_000);
+		assert_eq!(Balances::free_balance(&exiting), 0, "a quarantined node must not be paid");
+	});
+}
+
+#[test]
+fn a_decommissioned_node_is_not_paid() {
+	new_test_ext().execute_with(|| {
+		let (honest, retired) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_compute_child(10, &honest, &account(20), 7, 100, ChildStatus::Active);
+		seed_compute_child(11, &retired, &account(21), 7, 100, ChildStatus::Active);
+		set_operational_status(11, pallet_compute_scoring::MinerStatus::Decommissioned);
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&honest), 100_000);
+		assert_eq!(Balances::free_balance(&retired), 0);
+	});
+}
+
+#[test]
+fn an_absent_status_row_counts_as_active_and_is_paid() {
+	// `MinerStatuses` is OptionQuery and recovery to Active REMOVES the row, so
+	// "no row" is the normal state for a healthy node. Filtering it out would
+	// pay nobody at all — the failure mode this pins is the over-strict fix.
+	new_test_ext().execute_with(|| {
+		let family = account(2);
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_compute_child(10, &family, &account(20), 7, 100, ChildStatus::Active);
+		assert!(pallet_compute_scoring::MinerStatuses::<Runtime>::get([10u8; 32]).is_none());
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&family), 100_000);
+	});
+}
+
+#[test]
+fn the_same_epoch_cannot_be_paid_twice() {
+	// A retried transaction (submitter never saw the receipt) must not pay one
+	// epoch's weights a second time out of the compartment.
+	new_test_ext().execute_with(|| {
+		let family = account(2);
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_compute_child(10, &family, &account(20), 7, 100, ChildStatus::Active);
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 50_000));
+		assert_eq!(Balances::free_balance(&family), 50_000);
+
+		// Funds and daily budget both remain — only the replay guard stops this.
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 50_000),
+			pallet_hippocampus::Error::<Runtime>::ComputeEpochAlreadyPaid
+		);
+		assert_eq!(Balances::free_balance(&family), 50_000);
+
+		// The next close settles normally — the guard blocks replay, not progress.
+		seed_compute_child(10, &family, &account(20), 8, 100, ChildStatus::Active);
+		close_epoch(8);
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 50_000));
+		assert_eq!(Balances::free_balance(&family), 100_000);
+	});
+}
+
 /// Register a storage-miner node and append it to the ranked list — needed
 /// only to prove the shared 24-hour budget spans both payouts.
 fn seed_ranked_storage_miner(node_seed: u8, owner: &AccountId, weight: u16, is_active: bool) {
@@ -278,8 +382,8 @@ fn the_two_emission_compartments_do_not_mix() {
 }
 
 #[test]
-fn the_3500_alpha_daily_cap_is_shared_with_storage_payouts() {
-	// The 3500 alpha/24h budget is a TOTAL across both payouts, not one each:
+fn the_daily_cap_is_shared_with_storage_payouts() {
+	// The daily budget is a TOTAL across both payouts, not one each:
 	// spending it on storage miners leaves nothing for compute miners in the
 	// same period, however full the compute compartment is.
 	new_test_ext().execute_with(|| {

--- a/runtime/mainnet/tests/pay_compute_miners.rs
+++ b/runtime/mainnet/tests/pay_compute_miners.rs
@@ -1,0 +1,347 @@
+//! End-to-end: compute emission deposited into the bank is distributed to
+//! compute-miner *families* by `pay_compute_miners`, the runtime's
+//! `ComputeMinerWeightsSource` resolves node → child → family off the
+//! compute-scoring pallet's last-closed-epoch weights, and the compute
+//! emission compartment is invisible to the arion settlement headroom.
+
+use frame_support::traits::{Currency, Get};
+use frame_support::{assert_noop, assert_ok};
+use hippius_mainnet_runtime::{
+	AccountId, ArionPayoutSource, Balances, ComputeMinerWeightsSource, Hippocampus, Runtime,
+	RuntimeOrigin, System,
+};
+use pallet_arion::PayoutSource;
+use pallet_compute_scoring::{ChildRegistration, ChildStatus};
+use pallet_hippocampus::{ComputeMinerWeights, DepositType};
+use pallet_registration::{ColdkeyNodeInfoLite, NodeType, Status};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{AccountId32, BuildStorage};
+
+/// Must match `ExistentialDeposit` in the runtime.
+const ED: u128 = 500;
+
+/// The hardcoded `ArionAdminMembers` account (all arion/bank admin origins).
+fn admin() -> AccountId {
+	AccountId32::from_ss58check("5CVXqxb7mhFTtZVw5BJ8M2ujND9PFymSDxF8bkod6Sm4XJTW").unwrap()
+}
+
+fn account(seed: u8) -> AccountId {
+	AccountId32::new([seed; 32])
+}
+
+fn new_test_ext() -> sp_io::TestExternalities {
+	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
+/// Seed a compute child owned by `family`, and the epoch weight the validator
+/// reported for it in `epoch`. Mirrors what `register_child` +
+/// `vali_submit_epoch_close` write.
+fn seed_compute_child(
+	node_seed: u8,
+	family: &AccountId,
+	child: &AccountId,
+	epoch: u64,
+	weight: u128,
+	status: ChildStatus,
+) {
+	let node_id = [node_seed; 32];
+	pallet_compute_scoring::NodeIdToChild::<Runtime>::insert(node_id, child.clone());
+	pallet_compute_scoring::ChildRegistrations::<Runtime>::insert(
+		child.clone(),
+		ChildRegistration {
+			family: family.clone(),
+			node_id,
+			status,
+			deposit: 0u128,
+			unbonding_end: 0u64,
+		},
+	);
+	pallet_compute_scoring::EpochWeights::<Runtime>::insert(epoch, node_id, weight);
+}
+
+/// Register a storage-miner node and append it to the ranked list — needed
+/// only to prove the shared 24-hour budget spans both payouts.
+fn seed_ranked_storage_miner(node_seed: u8, owner: &AccountId, weight: u16, is_active: bool) {
+	let node_id = vec![node_seed; 32];
+	pallet_registration::ColdkeyNodeRegistrationV2::<Runtime>::insert(
+		node_id.clone(),
+		Some(ColdkeyNodeInfoLite {
+			node_id: node_id.clone(),
+			node_type: NodeType::StorageMiner,
+			status: Status::Online,
+			registered_at: 0u32.into(),
+			owner: owner.clone(),
+		}),
+	);
+	let mut list = pallet_rankings::RankedList::<Runtime>::get();
+	list.push(pallet_rankings::NodeRankings {
+		rank: u32::from(node_seed),
+		node_id,
+		node_ss58_address: owner.to_ss58check().into_bytes(),
+		node_type: NodeType::StorageMiner,
+		weight,
+		last_updated: 0u32.into(),
+		is_active,
+	});
+	pallet_rankings::RankedList::<Runtime>::put(list);
+}
+
+/// Close of `epoch`: `vali_submit_epoch_close` sets `CurrentEpoch = epoch`
+/// after writing that epoch's weights, so `CurrentEpoch` *is* the last closed
+/// epoch — the adapter reads exactly this.
+fn close_epoch(epoch: u64) {
+	pallet_compute_scoring::CurrentEpoch::<Runtime>::put(epoch);
+}
+
+/// Fund the bank with an ED cushion plus `emission` tagged as ComputeEmission,
+/// and whitelist the admin account as the payout caller.
+fn fund_bank_and_whitelist_admin(emission: u128) {
+	let funder = account(1);
+	Balances::make_free_balance_be(&funder, emission + 1_000_000);
+
+	assert_ok!(Hippocampus::deposit(
+		RuntimeOrigin::signed(funder.clone()),
+		ED * 2,
+		DepositType::Grant
+	));
+	assert_ok!(Hippocampus::deposit(
+		RuntimeOrigin::signed(funder),
+		emission,
+		DepositType::ComputeEmission
+	));
+	// AdminOrigin is EnsureSignedBy<ArionAdminMembers>, not root.
+	assert_ok!(Hippocampus::add_miner_payment_caller(RuntimeOrigin::signed(admin()), admin()));
+}
+
+#[test]
+fn compute_emission_compartment_invisible_to_arion_settlement() {
+	new_test_ext().execute_with(|| {
+		let funder = account(1);
+		Balances::make_free_balance_be(&funder, 1_000_000);
+
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder.clone()),
+			ED * 2,
+			DepositType::Grant
+		));
+		let arion_headroom_before = ArionPayoutSource::available();
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder),
+			100_000,
+			DepositType::ComputeEmission
+		));
+
+		// Wall: compute emission is invisible to the arion settlement headroom.
+		assert_eq!(ArionPayoutSource::available(), arion_headroom_before);
+		assert_eq!(Hippocampus::compute_emission_available(), 100_000);
+		// And it is not the storage compartment either.
+		assert_eq!(Hippocampus::emission_available(), 0);
+	});
+}
+
+#[test]
+fn pay_compute_miners_with_no_closed_epoch() {
+	new_test_ext().execute_with(|| {
+		fund_bank_and_whitelist_admin(100_000);
+
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000),
+			pallet_hippocampus::Error::<Runtime>::NoEligibleComputeMiners
+		);
+		assert_eq!(Hippocampus::compute_emission_available(), 100_000);
+	});
+}
+
+#[test]
+fn pay_compute_miners_distributes_to_families() {
+	new_test_ext().execute_with(|| {
+		let (family_a, family_b) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_compute_child(10, &family_a, &account(20), 7, 100, ChildStatus::Active);
+		seed_compute_child(11, &family_b, &account(21), 7, 300, ChildStatus::Active);
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&family_a), 25_000);
+		assert_eq!(Balances::free_balance(&family_b), 75_000);
+		// The child accounts themselves are never paid.
+		assert_eq!(Balances::free_balance(account(20)), 0);
+		assert_eq!(Balances::free_balance(account(21)), 0);
+		assert_eq!(Hippocampus::compute_emission_available(), 0);
+	});
+}
+
+#[test]
+fn a_family_running_several_nodes_gets_one_summed_transfer() {
+	new_test_ext().execute_with(|| {
+		let (family_a, family_b) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		// family_a runs three nodes summing to 300; family_b runs one at 100.
+		seed_compute_child(10, &family_a, &account(20), 7, 100, ChildStatus::Active);
+		seed_compute_child(11, &family_a, &account(21), 7, 100, ChildStatus::Active);
+		seed_compute_child(12, &family_a, &account(22), 7, 100, ChildStatus::Active);
+		seed_compute_child(13, &family_b, &account(23), 7, 100, ChildStatus::Active);
+		close_epoch(7);
+
+		// One entry per family, not per node.
+		let miners = ComputeMinerWeightsSource::active_compute_miners();
+		assert_eq!(miners.len(), 2);
+		assert_eq!(
+			miners.iter().find(|(who, _)| who == &family_a).map(|(_, w)| *w),
+			Some(300)
+		);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&family_a), 75_000);
+		assert_eq!(Balances::free_balance(&family_b), 25_000);
+	});
+}
+
+#[test]
+fn unbonding_unmapped_and_zero_weight_nodes_are_excluded() {
+	new_test_ext().execute_with(|| {
+		let (family_a, unbonding, quarantined) = (account(2), account(3), account(4));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_compute_child(10, &family_a, &account(20), 7, 100, ChildStatus::Active);
+		// Deregistered mid-epoch: weight was reported, but the operator is gone.
+		seed_compute_child(11, &unbonding, &account(21), 7, 300, ChildStatus::Unbonding);
+		// The validator reported an explicit zero-reward verdict.
+		seed_compute_child(12, &quarantined, &account(22), 7, 0, ChildStatus::Active);
+		// Weight reported for a node id that no longer maps to any child.
+		pallet_compute_scoring::EpochWeights::<Runtime>::insert(7u64, [13u8; 32], 300u128);
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		// Excluded nodes neither receive nor dilute the split.
+		assert_eq!(Balances::free_balance(&unbonding), 0);
+		assert_eq!(Balances::free_balance(&quarantined), 0);
+		assert_eq!(Balances::free_balance(&family_a), 100_000);
+	});
+}
+
+#[test]
+fn only_the_last_closed_epoch_is_paid() {
+	new_test_ext().execute_with(|| {
+		let (stale, current) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		// A node that earned in epoch 6 but was not reported in epoch 7.
+		seed_compute_child(10, &stale, &account(20), 6, 900, ChildStatus::Active);
+		seed_compute_child(11, &current, &account(21), 7, 100, ChildStatus::Active);
+		close_epoch(7);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&stale), 0);
+		assert_eq!(Balances::free_balance(&current), 100_000);
+	});
+}
+
+#[test]
+fn the_two_emission_compartments_do_not_mix() {
+	new_test_ext().execute_with(|| {
+		let family_a = account(2);
+		let funder = account(1);
+		Balances::make_free_balance_be(&funder, 10_000_000);
+
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder.clone()),
+			ED * 2,
+			DepositType::Grant
+		));
+		// Storage emission only — nothing for compute to spend.
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder),
+			100_000,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::add_miner_payment_caller(RuntimeOrigin::signed(admin()), admin()));
+
+		seed_compute_child(10, &family_a, &account(20), 7, 100, ChildStatus::Active);
+		close_epoch(7);
+
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 100_000),
+			pallet_hippocampus::Error::<Runtime>::InsufficientComputeEmissionFunds
+		);
+		assert_eq!(Hippocampus::emission_available(), 100_000);
+	});
+}
+
+#[test]
+fn the_3500_alpha_daily_cap_is_shared_with_storage_payouts() {
+	// The 3500 alpha/24h budget is a TOTAL across both payouts, not one each:
+	// spending it on storage miners leaves nothing for compute miners in the
+	// same period, however full the compute compartment is.
+	new_test_ext().execute_with(|| {
+		let cap = <Runtime as pallet_hippocampus::Config>::Max24HourMinerPayout::get();
+		let family_a = account(2);
+		let storage_miner = account(9);
+		let funder = account(1);
+		Balances::make_free_balance_be(&funder, cap.saturating_mul(4));
+
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder.clone()),
+			ED * 2,
+			DepositType::Grant
+		));
+		// Each compartment is funded with the full daily cap on its own.
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder.clone()),
+			cap,
+			DepositType::Emission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(funder),
+			cap,
+			DepositType::ComputeEmission
+		));
+		assert_ok!(Hippocampus::add_miner_payment_caller(RuntimeOrigin::signed(admin()), admin()));
+
+		seed_ranked_storage_miner(30, &storage_miner, 100, true);
+		seed_compute_child(10, &family_a, &account(20), 7, 100, ChildStatus::Active);
+		close_epoch(7);
+
+		// Storage takes the whole day's budget.
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), cap));
+		assert_eq!(Balances::free_balance(&storage_miner), cap);
+
+		// Compute is rate-limited out even though its compartment is full.
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), 1),
+			pallet_hippocampus::Error::<Runtime>::ExceedsDaily24HourMinerPayoutLimit
+		);
+		assert_eq!(Hippocampus::compute_emission_available(), cap);
+
+		// Next period, the shared budget refills once and compute can draw it.
+		System::set_block_number(
+			<Runtime as pallet_hippocampus::Config>::BlocksPer24Hours::get() + 1,
+		);
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), cap));
+		assert_eq!(Balances::free_balance(&family_a), cap);
+	});
+}
+
+#[test]
+fn compute_payout_slot_bound_covers_every_family() {
+	// The payee is a family, so the bank's per-call bound only has to cover
+	// `MaxFamilies` — this pins that relationship so raising MaxFamilies
+	// without raising the bound fails loudly here rather than as a runtime
+	// `TooManyComputeMiners` in production.
+	let max_families: u32 = <Runtime as pallet_compute_scoring::Config>::MaxFamilies::get();
+	let max_payees: u32 =
+		<Runtime as pallet_hippocampus::Config>::MaxComputeMinersPerPayout::get();
+	assert!(
+		max_payees >= max_families,
+		"MaxComputeMinersPerPayout ({max_payees}) must cover MaxFamilies ({max_families})"
+	);
+}

--- a/runtime/mainnet/tests/pay_compute_miners.rs
+++ b/runtime/mainnet/tests/pay_compute_miners.rs
@@ -332,16 +332,148 @@ fn the_3500_alpha_daily_cap_is_shared_with_storage_payouts() {
 }
 
 #[test]
-fn compute_payout_slot_bound_covers_every_family() {
-	// The payee is a family, so the bank's per-call bound only has to cover
-	// `MaxFamilies` — this pins that relationship so raising MaxFamilies
-	// without raising the bound fails loudly here rather than as a runtime
-	// `TooManyComputeMiners` in production.
-	let max_families: u32 = <Runtime as pallet_compute_scoring::Config>::MaxFamilies::get();
+fn compute_payout_slot_bound_covers_an_epoch_close_batch() {
+	// The binding constraint on the bank's per-call bound is
+	// `MaxMinerStatusUpdatesPerCall`, NOT `MaxFamilies`.
+	//
+	// `vali_submit_epoch_close` requires `epoch > CurrentEpoch` and then sets
+	// `CurrentEpoch = epoch`, so exactly one close call can ever write a given
+	// epoch's `EpochWeights`. The adapter reads that single epoch and folds it
+	// by family, so the payee count is capped by the size of one close batch —
+	// at most `MaxMinerStatusUpdatesPerCall` entries, hence at most that many
+	// distinct families, however many families are registered chain-wide.
+	//
+	// This pins the invariant stated at `MaxComputeMinersPerPayout` in the
+	// runtime: raising the batch size past the bound fails loudly here rather
+	// than as a `TooManyComputeMiners` that bricks every payout in production.
+	let max_batch: u32 =
+		<Runtime as pallet_compute_scoring::Config>::MaxMinerStatusUpdatesPerCall::get();
 	let max_payees: u32 =
 		<Runtime as pallet_hippocampus::Config>::MaxComputeMinersPerPayout::get();
 	assert!(
-		max_payees >= max_families,
-		"MaxComputeMinersPerPayout ({max_payees}) must cover MaxFamilies ({max_families})"
+		max_payees >= max_batch,
+		"MaxComputeMinersPerPayout ({max_payees}) must cover \
+		 MaxMinerStatusUpdatesPerCall ({max_batch})"
 	);
+
+	// `MaxFamilies` is a second, looser ceiling on distinct payees. It is not
+	// asserted as a requirement: it can only bind after the batch bound does,
+	// so requiring `max_payees >= MaxFamilies` would fail spuriously if
+	// MaxFamilies were raised. Recorded here so the ordering is deliberate.
+	let max_families: u32 = <Runtime as pallet_compute_scoring::Config>::MaxFamilies::get();
+	assert!(
+		max_batch <= max_families,
+		"a close batch ({max_batch}) cannot name more families than exist ({max_families})"
+	);
+}
+
+/// `account()` derives from a single `u8` and so yields only 256 distinct ids —
+/// not enough for a full-batch test that needs a family *and* a child per entry.
+/// Tag-plus-index keeps every account and node id distinct.
+fn indexed_account(tag: u8, i: u32) -> AccountId {
+	let mut raw = [0u8; 32];
+	raw[0] = tag;
+	raw[1..5].copy_from_slice(&i.to_le_bytes());
+	AccountId32::new(raw)
+}
+
+fn indexed_node_id(i: u32) -> [u8; 32] {
+	let mut raw = [0xAAu8; 32];
+	raw[1..5].copy_from_slice(&i.to_le_bytes());
+	raw
+}
+
+#[test]
+fn a_full_close_batch_of_families_is_actually_paid() {
+	// The behavioural counterpart to the two constant assertions below: seed a
+	// full `MaxMinerStatusUpdatesPerCall` batch of distinct families, every one
+	// carrying the maximum permitted weight, and run the real payout.
+	//
+	// This is what proves the bound holds in practice — it exercises the
+	// BoundedVec construction that would raise `TooManyComputeMiners`, and the
+	// widest denominator the runtime can actually produce.
+	new_test_ext().execute_with(|| {
+		let batch: u32 =
+			<Runtime as pallet_compute_scoring::Config>::MaxMinerStatusUpdatesPerCall::get();
+		let max_weight = pallet_compute_scoring::MaxEpochWeightPerNode::<Runtime>::get();
+
+		// Per-family share must clear the existential deposit, or the transfers
+		// would fail and be silently skipped — which would make this test pass
+		// while proving nothing.
+		let per_family = ED * 2;
+		let amount = per_family * u128::from(batch);
+		fund_bank_and_whitelist_admin(amount);
+
+		let families: Vec<AccountId> = (0..batch).map(|i| indexed_account(0x11, i)).collect();
+		for (i, family) in families.iter().enumerate() {
+			let i = i as u32;
+			let child = indexed_account(0x22, i);
+			let node_id = indexed_node_id(i);
+			pallet_compute_scoring::NodeIdToChild::<Runtime>::insert(node_id, child.clone());
+			pallet_compute_scoring::ChildRegistrations::<Runtime>::insert(
+				child,
+				ChildRegistration {
+					family: family.clone(),
+					node_id,
+					status: ChildStatus::Active,
+					deposit: 0u128,
+					unbonding_end: 0u64,
+				},
+			);
+			pallet_compute_scoring::EpochWeights::<Runtime>::insert(9, node_id, max_weight);
+		}
+		close_epoch(9);
+
+		// The adapter must surface every family — if it collapsed or dropped
+		// entries the payout assertions below would still pass vacuously.
+		assert_eq!(ComputeMinerWeightsSource::active_compute_miners().len(), batch as usize);
+
+		assert_ok!(Hippocampus::pay_compute_miners(RuntimeOrigin::signed(admin()), amount));
+
+		for family in &families {
+			assert_eq!(
+				Balances::free_balance(family),
+				per_family,
+				"every family in a full batch must be paid its equal share"
+			);
+		}
+		assert_eq!(Hippocampus::compute_emission_available(), 0, "every planck accounted for");
+	});
+}
+
+#[test]
+fn a_full_epoch_batch_of_max_weights_cannot_saturate_the_denominator() {
+	// `pay_compute_miners` sums a whole epoch's weights into a u128 denominator
+	// and divides the payout by it. `MaxEpochWeightPerNode` (u64::MAX by
+	// default) exists to keep that sum far inside u128 — the fund-conservation
+	// argument breaks if it can saturate.
+	//
+	// This pins the worst case the runtime can actually produce: a full close
+	// batch where every entry carries the maximum permitted weight. There is no
+	// setter extrinsic for `MaxEpochWeightPerNode`, so the default is the
+	// operative value; a sudo `set_storage` that raised it toward u128::MAX
+	// would invalidate this, which is exactly what the pallet doc warns about.
+	// Annotate before widening: `ConstU32` satisfies both `Get<u32>` and
+	// `Get<Option<u32>>`, so `u128::from(..::get())` alone is ambiguous.
+	let max_batch: u32 =
+		<Runtime as pallet_compute_scoring::Config>::MaxMinerStatusUpdatesPerCall::get();
+	let max_batch = u128::from(max_batch);
+
+	// `MaxEpochWeightPerNode` is storage with a `type_value` default, not a
+	// Config constant, so reading it needs an externalities environment.
+	new_test_ext().execute_with(|| {
+		let max_weight = pallet_compute_scoring::MaxEpochWeightPerNode::<Runtime>::get();
+		assert_eq!(max_weight, u64::MAX as u128, "the documented default is the operative value");
+
+		let total = max_batch
+			.checked_mul(max_weight)
+			.expect("a full max-weight close batch must not overflow the u128 denominator");
+
+		// Not merely non-overflowing: leave room for the payout numerator, which
+		// is multiplied by a weight before the division.
+		assert!(
+			total <= u128::MAX / 1_000_000,
+			"denominator {total} leaves too little headroom for the payout numerator"
+		);
+	});
 }

--- a/runtime/mainnet/tests/pay_storage_miners.rs
+++ b/runtime/mainnet/tests/pay_storage_miners.rs
@@ -212,6 +212,10 @@ fn daily_miner_payout_cap_is_3500_alpha() {
 	// Guards the 18-decimals scaling of the cap: the constant originally
 	// shipped 1000x too small (3 alpha instead of 3000). If the intended
 	// daily cap changes, change this test together with the runtime value.
+	//
+	// 3500 is the COMBINED ceiling for `pay_storage_miners` +
+	// `pay_compute_miners`, not a per-payout allowance. Adding a consumer to
+	// the shared counter is not a reason to raise it.
 	const UNIT: u128 = 1_000_000_000_000_000_000;
 	assert_eq!(<Runtime as pallet_hippocampus::Config>::Max24HourMinerPayout::get(), 3_500 * UNIT);
 }


### PR DESCRIPTION
Adds `hippocampus.pay_compute_miners(amount)` — the compute-miner counterpart of the existing `pay_storage_miners`.

It distributes `amount` to compute-miner families, pro-rata by the reward weight the validators wrote for the last closed epoch.

## How it works

- **Weights** come from `pallet-compute-scoring`'s `EpochWeights` at `CurrentEpoch` (which *is* the last closed epoch — `vali_submit_epoch_close` writes the weights and then advances the counter). Not from `RankingCompute`.
- **Payee** is the `family` account, resolved `node_id → NodeIdToChild → ChildRegistrations.family`. A family running several nodes gets one transfer with its weights summed.
- Non-`Active` children and node ids that no longer map to a child are skipped — they neither get paid nor dilute the split.

## Funds


- **Weights** come from `pallet-compute-scoring`'s `EpochWeights` at `CurrentEpoch` (which *is* the last closed epoch — `vali_submit_epoch_close` writes the weights and then advances the counter). Not from `RankingCompute`.
- **Payee** is the `family` account, resolved `node_id → NodeIdToChild → ChildRegistrations.family`. A family running several nodes gets one transfer with its weights summed.
- Non-`Active` children and node ids that no longer map to a child are skipped — they neither get paid nor dilute the split.

## Funds

- New `DepositType::ComputeEmission` compartment with its own `ComputeEmissionPaidOut` ledger. Storage and compute emission cannot spend each other.
- The 24-hour rate limit is **shared**: 3500 alpha per day total across both payouts, not 3500 each.
- `ArionPayoutSource` and the marketplace referral headroom now subtract the new compartment, so it stays walled off from other bank consumers.
- Callers are gated by the existing `MinerPaymentWhitelist` (admin-managed) — the same whitelist `pay_storage_miners` uses.