### PR TITLE
fix(hippocampus): pay storage miners from arion, not rankings

### DIFF
--- a/pallets/arion-pallet/src/family_weights.rs
+++ b/pallets/arion-pallet/src/family_weights.rs
@@ -23,8 +23,10 @@ use sp_std::prelude::*;
 /// Sum each family's eligible child weights.
 ///
 /// * `families` — every family and its child list.
-/// * `is_eligible` — whether a child currently counts (Active registration,
-///   weight not stale).
+/// * `is_eligible` — whether a child counts **toward this family**: called
+///   with `(family, child)` so the implementation can confirm the child's own
+///   registration names the family whose list it was found under, on top of
+///   the Active/freshness checks.
 /// * `node_weight` — the child's latest reported node weight.
 ///
 /// Families whose eligible children sum to zero are **dropped**, not returned
@@ -40,7 +42,7 @@ use sp_std::prelude::*;
 /// value and silently equalizing shares the payout is supposed to separate.
 pub fn sum_family_weights<AccountId, Children>(
 	families: impl Iterator<Item = (AccountId, Children)>,
-	is_eligible: impl Fn(&AccountId) -> bool,
+	is_eligible: impl Fn(&AccountId, &AccountId) -> bool,
 	node_weight: impl Fn(&AccountId) -> u16,
 ) -> Vec<(AccountId, u128)>
 where
@@ -50,7 +52,7 @@ where
 	for (family, children) in families {
 		let mut total: u128 = 0;
 		for child in children {
-			if !is_eligible(&child) {
+			if !is_eligible(&family, &child) {
 				continue;
 			}
 			total = total.saturating_add(u128::from(node_weight(&child)));
@@ -83,7 +85,7 @@ mod tests {
 		let (eligible, weights) = env(&[(1, true, 10), (2, true, 25), (3, true, 5)]);
 		let out = sum_family_weights(
 			vec![(100u8, vec![1u8, 2, 3])].into_iter(),
-			|c| eligible[c],
+			|_f, c| eligible[c],
 			|c| weights[c],
 		);
 		assert_eq!(out, vec![(100, 40)]);
@@ -95,7 +97,7 @@ mod tests {
 		let (eligible, weights) = env(&[(1, true, 10), (2, false, 25), (3, true, 5)]);
 		let out = sum_family_weights(
 			vec![(100u8, vec![1u8, 2, 3])].into_iter(),
-			|c| eligible[c],
+			|_f, c| eligible[c],
 			|c| weights[c],
 		);
 		assert_eq!(out, vec![(100, 15)]);
@@ -106,7 +108,7 @@ mod tests {
 		let (eligible, weights) = env(&[(1, false, 10), (2, false, 25)]);
 		let out = sum_family_weights(
 			vec![(100u8, vec![1u8, 2])].into_iter(),
-			|c| eligible[c],
+			|_f, c| eligible[c],
 			|c| weights[c],
 		);
 		assert!(out.is_empty());
@@ -118,7 +120,7 @@ mod tests {
 		let (eligible, weights) = env(&[(1, true, 0), (2, true, 0)]);
 		let out = sum_family_weights(
 			vec![(100u8, vec![1u8, 2])].into_iter(),
-			|c| eligible[c],
+			|_f, c| eligible[c],
 			|c| weights[c],
 		);
 		assert!(out.is_empty());
@@ -126,7 +128,8 @@ mod tests {
 
 	#[test]
 	fn family_with_no_children_is_dropped() {
-		let out = sum_family_weights(vec![(100u8, Vec::<u8>::new())].into_iter(), |_| true, |_| 10);
+		let out =
+			sum_family_weights(vec![(100u8, Vec::<u8>::new())].into_iter(), |_, _| true, |_| 10);
 		assert!(out.is_empty());
 	}
 
@@ -136,7 +139,7 @@ mod tests {
 			env(&[(1, true, 10), (2, true, 10), (3, true, 30), (4, false, 1_000)]);
 		let out = sum_family_weights(
 			vec![(100u8, vec![1u8, 2]), (200u8, vec![3u8, 4])].into_iter(),
-			|c| eligible[c],
+			|_f, c| eligible[c],
 			|c| weights[c],
 		);
 		// Two nodes at 10 lose to one node at 30 — share follows summed
@@ -148,10 +151,27 @@ mod tests {
 	fn family_total_exceeds_u16_without_saturating() {
 		// 35 children (the runtime's MaxChildrenPerFamily) at MaxNodeWeight.
 		let children: Vec<u8> = (1..=35).collect();
-		let out = sum_family_weights(vec![(100u8, children)].into_iter(), |_| true, |_| 50_000);
+		let out =
+			sum_family_weights(vec![(100u8, children)].into_iter(), |_, _| true, |_| 50_000);
 		assert_eq!(out, vec![(100, 1_750_000)]);
 		// The point of the u128 accumulator: a u16 one would have stopped here.
 		assert!(out[0].1 > u128::from(u16::MAX));
+	}
+
+	#[test]
+	fn a_child_registered_to_another_family_is_not_counted() {
+		// The child list is one index and the child's own registration is
+		// another. If they ever disagree, the registration wins: a family must
+		// never be credited for weight belonging to a child it does not own.
+		let owner: BTreeMap<u8, u8> = [(1u8, 100u8), (2, 100), (3, 200)].into_iter().collect();
+		let out = sum_family_weights(
+			// Family 100's list wrongly contains child 3, which is registered
+			// to family 200.
+			vec![(100u8, vec![1u8, 2, 3])].into_iter(),
+			|f, c| owner[c] == *f,
+			|_| 10,
+		);
+		assert_eq!(out, vec![(100, 20)]);
 	}
 
 	#[test]
@@ -159,7 +179,7 @@ mod tests {
 		// Same per-node weight on both sides: three nodes beat one, 3:1.
 		let out = sum_family_weights(
 			vec![(100u8, vec![1u8, 2, 3]), (200u8, vec![4u8])].into_iter(),
-			|_| true,
+			|_, _| true,
 			|_| 50_000,
 		);
 		let small = out.iter().find(|(f, _)| *f == 200).unwrap().1;

--- a/pallets/arion-pallet/src/family_weights.rs
+++ b/pallets/arion-pallet/src/family_weights.rs
@@ -151,8 +151,7 @@ mod tests {
 	fn family_total_exceeds_u16_without_saturating() {
 		// 35 children (the runtime's MaxChildrenPerFamily) at MaxNodeWeight.
 		let children: Vec<u8> = (1..=35).collect();
-		let out =
-			sum_family_weights(vec![(100u8, children)].into_iter(), |_, _| true, |_| 50_000);
+		let out = sum_family_weights(vec![(100u8, children)].into_iter(), |_, _| true, |_| 50_000);
 		assert_eq!(out, vec![(100, 1_750_000)]);
 		// The point of the u128 accumulator: a u16 one would have stopped here.
 		assert!(out[0].1 > u128::from(u16::MAX));

--- a/pallets/arion-pallet/src/family_weights.rs
+++ b/pallets/arion-pallet/src/family_weights.rs
@@ -1,0 +1,169 @@
+//! Per-family payout weight: the sum of the node weights of a family's
+//! eligible children.
+//!
+//! This is the weight the bank (`pallet-hippocampus::pay_storage_miners`)
+//! distributes storage emission by — a family's share of a payout is its
+//! summed child weight over the summed child weight of every family, so the
+//! family running the most/best-weighted nodes is paid the most.
+//!
+//! Deliberately NOT [`FamilyWeight`](crate::pallet::FamilyWeight): that is the
+//! EMA-smoothed, delta-clamped *quality score* published to external consumers
+//! (e.g. Bittensor). Emission is paid on the raw sum of what the family's nodes
+//! are currently weighted at, so the payout tracks the validator-reported node
+//! weights directly with no smoothing lag.
+//!
+//! The aggregation is a free function over iterators rather than a method on
+//! `Pallet<T>` so it can be unit-tested without a mock runtime — Arion's
+//! `Config` inherits `pallet_registration::Config`, whose own supertraits
+//! (babe / staking / credits / balances / proxy) make a test runtime for this
+//! pallet impractical.
+
+use sp_std::prelude::*;
+
+/// Sum each family's eligible child weights.
+///
+/// * `families` — every family and its child list.
+/// * `is_eligible` — whether a child currently counts (Active registration,
+///   weight not stale).
+/// * `node_weight` — the child's latest reported node weight.
+///
+/// Families whose eligible children sum to zero are **dropped**, not returned
+/// with a zero weight: the bank caps how many payees one payout may carry
+/// (`MaxMinersPerPayout`) and rejects the whole call above it, so padding the
+/// list with families that would receive nothing can fail a payout that had
+/// room for every family that actually earns.
+///
+/// Weights are widened to `u128` before summing. `u16` is the width of one
+/// *node* weight, not of a family: at the runtime's bounds (35 children x
+/// `MaxNodeWeight` 50_000) a family total reaches 1_750_000 and would saturate
+/// a `u16` accumulator at 65_535, flattening every large family onto the same
+/// value and silently equalizing shares the payout is supposed to separate.
+pub fn sum_family_weights<AccountId, Children>(
+	families: impl Iterator<Item = (AccountId, Children)>,
+	is_eligible: impl Fn(&AccountId) -> bool,
+	node_weight: impl Fn(&AccountId) -> u16,
+) -> Vec<(AccountId, u128)>
+where
+	Children: IntoIterator<Item = AccountId>,
+{
+	let mut out = Vec::new();
+	for (family, children) in families {
+		let mut total: u128 = 0;
+		for child in children {
+			if !is_eligible(&child) {
+				continue;
+			}
+			total = total.saturating_add(u128::from(node_weight(&child)));
+		}
+		if total > 0 {
+			out.push((family, total));
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_std::collections::btree_map::BTreeMap;
+
+	/// Children keyed by id: `(eligible, weight)`.
+	fn env(entries: &[(u8, bool, u16)]) -> (BTreeMap<u8, bool>, BTreeMap<u8, u16>) {
+		let mut eligible = BTreeMap::new();
+		let mut weights = BTreeMap::new();
+		for (id, ok, w) in entries {
+			eligible.insert(*id, *ok);
+			weights.insert(*id, *w);
+		}
+		(eligible, weights)
+	}
+
+	#[test]
+	fn sums_every_eligible_child_of_a_family() {
+		let (eligible, weights) = env(&[(1, true, 10), (2, true, 25), (3, true, 5)]);
+		let out = sum_family_weights(
+			vec![(100u8, vec![1u8, 2, 3])].into_iter(),
+			|c| eligible[c],
+			|c| weights[c],
+		);
+		assert_eq!(out, vec![(100, 40)]);
+	}
+
+	#[test]
+	fn ineligible_children_contribute_nothing() {
+		// Child 2 is deregistered/stale: its 25 must not be paid for.
+		let (eligible, weights) = env(&[(1, true, 10), (2, false, 25), (3, true, 5)]);
+		let out = sum_family_weights(
+			vec![(100u8, vec![1u8, 2, 3])].into_iter(),
+			|c| eligible[c],
+			|c| weights[c],
+		);
+		assert_eq!(out, vec![(100, 15)]);
+	}
+
+	#[test]
+	fn family_with_no_eligible_children_is_dropped() {
+		let (eligible, weights) = env(&[(1, false, 10), (2, false, 25)]);
+		let out = sum_family_weights(
+			vec![(100u8, vec![1u8, 2])].into_iter(),
+			|c| eligible[c],
+			|c| weights[c],
+		);
+		assert!(out.is_empty());
+	}
+
+	#[test]
+	fn family_whose_children_all_weigh_zero_is_dropped() {
+		// Eligible but unweighted (never scored) — still nothing to pay.
+		let (eligible, weights) = env(&[(1, true, 0), (2, true, 0)]);
+		let out = sum_family_weights(
+			vec![(100u8, vec![1u8, 2])].into_iter(),
+			|c| eligible[c],
+			|c| weights[c],
+		);
+		assert!(out.is_empty());
+	}
+
+	#[test]
+	fn family_with_no_children_is_dropped() {
+		let out = sum_family_weights(vec![(100u8, Vec::<u8>::new())].into_iter(), |_| true, |_| 10);
+		assert!(out.is_empty());
+	}
+
+	#[test]
+	fn each_family_is_summed_independently() {
+		let (eligible, weights) =
+			env(&[(1, true, 10), (2, true, 10), (3, true, 30), (4, false, 1_000)]);
+		let out = sum_family_weights(
+			vec![(100u8, vec![1u8, 2]), (200u8, vec![3u8, 4])].into_iter(),
+			|c| eligible[c],
+			|c| weights[c],
+		);
+		// Two nodes at 10 lose to one node at 30 — share follows summed
+		// weight, not child count.
+		assert_eq!(out, vec![(100, 20), (200, 30)]);
+	}
+
+	#[test]
+	fn family_total_exceeds_u16_without_saturating() {
+		// 35 children (the runtime's MaxChildrenPerFamily) at MaxNodeWeight.
+		let children: Vec<u8> = (1..=35).collect();
+		let out = sum_family_weights(vec![(100u8, children)].into_iter(), |_| true, |_| 50_000);
+		assert_eq!(out, vec![(100, 1_750_000)]);
+		// The point of the u128 accumulator: a u16 one would have stopped here.
+		assert!(out[0].1 > u128::from(u16::MAX));
+	}
+
+	#[test]
+	fn larger_family_total_wins_a_bigger_share() {
+		// Same per-node weight on both sides: three nodes beat one, 3:1.
+		let out = sum_family_weights(
+			vec![(100u8, vec![1u8, 2, 3]), (200u8, vec![4u8])].into_iter(),
+			|_| true,
+			|_| 50_000,
+		);
+		let small = out.iter().find(|(f, _)| *f == 200).unwrap().1;
+		let large = out.iter().find(|(f, _)| *f == 100).unwrap().1;
+		assert_eq!(large, small * 3);
+	}
+}

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod family_weights;
 pub mod weights;
 pub use weights::WeightInfo;
 
@@ -2284,6 +2285,49 @@ pub mod pallet {
 			let pen = pen_total / fresh_children;
 			let final_score = with_uptime.saturating_sub(pen).min(max_score);
 			final_score as u16
+		}
+
+		/// Active families and the payout weight the storage-emission bank
+		/// distributes by: for each family, the **sum of the node weights of
+		/// its eligible children**.
+		///
+		/// A child is eligible when it is both:
+		///
+		/// * `ChildRegistrations[child].status == Active` — a child that
+		///   deregistered is in `Unbonding` with its deposit on the way out,
+		///   so it has nothing at risk and must not keep earning; and
+		/// * **fresh** — its weight was last reported within
+		///   `StaleChildBuckets` of `CurrentWeightBucket`. `NodeWeightByChild`
+		///   keeps a node's last value until `prune_stale_node_weights` gets
+		///   to it, so without the freshness check a node that went offline
+		///   would be paid on its final good weight indefinitely.
+		///
+		/// These are exactly the two filters `compute_family_weight_from_nodes`
+		/// applies, so a family cannot be eligible for scoring and ineligible
+		/// for payment or vice versa.
+		///
+		/// Families are the payees: emission goes to the account that put up
+		/// the child deposits, not to the child accounts. Each family appears
+		/// at most once — `FamilyChildren` is keyed by family — which is the
+		/// bank's "one payee, one entry" contract.
+		///
+		/// Cost is bounded by the registration caps, not by the caller:
+		/// at most `MaxFamilies` keys scanned and `MaxChildrenTotal` children
+		/// read across all of them (3 reads each).
+		pub fn active_family_weights() -> Vec<(T::AccountId, u128)> {
+			let bucket = CurrentWeightBucket::<T>::get();
+			let stale = T::StaleChildBuckets::get();
+			crate::family_weights::sum_family_weights(
+				FamilyChildren::<T>::iter(),
+				|child| {
+					let active = matches!(
+						ChildRegistrations::<T>::get(child),
+						Some(reg) if reg.status == ChildStatus::Active
+					);
+					active && bucket.saturating_sub(NodeWeightLastBucket::<T>::get(child)) <= stale
+				},
+				|child| NodeWeightByChild::<T>::get(child),
+			)
 		}
 
 		pub fn get_total_family_weight() -> u128 {

--- a/pallets/arion-pallet/src/lib.rs
+++ b/pallets/arion-pallet/src/lib.rs
@@ -2291,8 +2291,10 @@ pub mod pallet {
 		/// distributes by: for each family, the **sum of the node weights of
 		/// its eligible children**.
 		///
-		/// A child is eligible when it is both:
+		/// A child is eligible when all of the following hold:
 		///
+		/// * `ChildRegistrations[child].family == family` — the child's own
+		///   registration names the family whose list it was found under; and
 		/// * `ChildRegistrations[child].status == Active` — a child that
 		///   deregistered is in `Unbonding` with its deposit on the way out,
 		///   so it has nothing at risk and must not keep earning; and
@@ -2319,12 +2321,18 @@ pub mod pallet {
 			let stale = T::StaleChildBuckets::get();
 			crate::family_weights::sum_family_weights(
 				FamilyChildren::<T>::iter(),
-				|child| {
-					let active = matches!(
-						ChildRegistrations::<T>::get(child),
-						Some(reg) if reg.status == ChildStatus::Active
-					);
-					active && bucket.saturating_sub(NodeWeightLastBucket::<T>::get(child)) <= stale
+				|family, child| {
+					let Some(reg) = ChildRegistrations::<T>::get(child) else { return false };
+					// The child's OWN registration must name the family whose
+					// list it was found under. `FamilyChildren` and
+					// `ChildRegistrations` are two indexes of one fact, kept in
+					// step by `register_child` / `deregister_child`; this makes
+					// "a family is only paid for children it owns" enforced
+					// here rather than assumed of every future writer. The read
+					// is already needed for the status check, so it is free.
+					reg.family == *family
+						&& reg.status == ChildStatus::Active
+						&& bucket.saturating_sub(NodeWeightLastBucket::<T>::get(child)) <= stale
 				},
 				|child| NodeWeightByChild::<T>::get(child),
 			)

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -395,16 +395,16 @@ pub mod pallet {
 		InsufficientComputeEmissionFunds,
 		/// The weighted compute-miner list exceeds `MaxComputeMinersPerPayout`.
 		TooManyComputeMiners,
-		/// The weight source returned a set whose weights sum past `u128`.
-		/// Both payouts reject rather than settle: a saturated denominator
-		/// inflates every pro-rata share and can overdraw the compartment.
-		/// Appended last on purpose — `Error` variants are metadata-indexed.
-		WeightSumOverflow,
 		/// No compute miner carries a non-zero weight this window.
 		NoEligibleComputeMiners,
 		/// This compute epoch has already been settled. Re-paying it would
 		/// pay the same epoch's work twice; wait for the next epoch close.
 		ComputeEpochAlreadyPaid,
+		/// The weight source returned a set whose weights sum past `u128`.
+		/// Both payouts reject rather than settle: a saturated denominator
+		/// inflates every pro-rata share and can overdraw the compartment.
+		/// Appended last on purpose — `Error` variants are metadata-indexed.
+		WeightSumOverflow,
 	}
 
 	#[pallet::call]

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -13,7 +13,9 @@
 //!   actually paid; the caller is responsible for handling shortfalls. Fails with
 //!   `DistributionDisabled` while the global switch is off.
 //! - `pay_storage_miners(amount)`: admin-gated; distributes `amount` from the
-//!   emission compartment to ranked storage miners pro-rata by ranking weight.
+//!   emission compartment to Arion storage families pro-rata by weight — a
+//!   family's weight is the sum of the node weights of its eligible children,
+//!   so the operator running the most/best-weighted nodes is paid the most.
 //! - `pay_compute_miners(amount)`: admin-gated; distributes `amount` from the
 //!   *compute* emission compartment to compute miners pro-rata by their
 //!   epoch reward weight. Its compartment (`DepositType::ComputeEmission`)
@@ -53,14 +55,40 @@ pub mod pallet {
 	pub type BalanceOf<T> =
 		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-	/// Ranked storage miners the bank distributes emission to.
+	/// Storage miners the bank distributes the storage emission compartment to.
 	///
-	/// Implemented by the runtime against the storage-ranking pallet so the
-	/// bank stays decoupled from where rankings come from.
-	pub trait StorageMinerRanking<AccountId> {
-		/// Payout account and current ranking weight of every active storage
-		/// miner. Zero-weight entries receive nothing.
-		fn active_storage_miners() -> Vec<(AccountId, u16)>;
+	/// Implemented by the runtime against the Arion pallet's family/child
+	/// registry and its validator-reported node weights, so the bank stays
+	/// decoupled from where those weights come from.
+	pub trait StorageMinerWeights<AccountId> {
+		/// Payout account and weight of every storage miner eligible for the
+		/// current payout window. Zero-weight entries receive nothing.
+		///
+		/// Weights are `u128`, not the `u16` a single Arion *node* weight is
+		/// stored as: a payee is a family, and a family's weight is the sum
+		/// over its children, which overruns `u16` well inside the runtime's
+		/// registration caps.
+		///
+		/// **Caller contract**: each payout account MUST appear at most once —
+		/// the implementation is responsible for aggregating the weights of
+		/// every node belonging to the same payee. A repeated account is not
+		/// unsound (it just receives several transfers), but it burns one of
+		/// the `MaxMinersPerPayout` slots per node instead of per payee.
+		///
+		/// **Caller contract**: the returned weights MUST sum to strictly less
+		/// than `u128::MAX`. The bank folds them into a single `u128`
+		/// denominator with `saturating_add`; a sum that saturated would be an
+		/// under-sized denominator and the pro-rata shares could then exceed
+		/// the requested payout, overdrawing the compartment. The production
+		/// implementation inherits this from Arion's per-node `MaxNodeWeight`
+		/// cap over a bounded child count — an implementation without an
+		/// equivalent per-entry bound must impose one itself.
+		///
+		/// **Caller contract**: the read cost of this call is NOT covered by
+		/// `WeightInfo::pay_storage_miners`'s per-miner term; the
+		/// implementation's scan must be bounded by on-chain caps rather than
+		/// by anything a caller supplies.
+		fn active_storage_miners() -> Vec<(AccountId, u128)>;
 	}
 
 	/// Compute miners the bank distributes the compute emission compartment to.
@@ -72,8 +100,7 @@ pub mod pallet {
 		/// Payout account and reward weight of every compute miner eligible
 		/// for the current payout window. Zero-weight entries receive nothing.
 		///
-		/// Weights are `u128` (the compute-scoring `EpochWeights` width, not
-		/// the `u16` the storage ranking uses).
+		/// Weights are `u128` (the compute-scoring `EpochWeights` width).
 		///
 		/// **Caller contract**: each payout account MUST appear at most once —
 		/// the implementation is responsible for aggregating the weights of
@@ -95,7 +122,7 @@ pub mod pallet {
 		/// Identifier of the settlement period the weights above belong to,
 		/// used by the bank as an idempotency key.
 		///
-		/// Unlike the storage ranking — a rolling "current standing" that can
+		/// Unlike the storage weights — a rolling "current standing" that can
 		/// legitimately be paid any number of times — compute weights are a
 		/// *per-epoch entitlement*: `EpochWeights[epoch]` is written once and
 		/// never changes, so paying the same epoch twice pays the same work
@@ -132,10 +159,10 @@ pub mod pallet {
 		/// Origin allowed to manage the requester whitelist.
 		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
-		/// Ranked storage miners paid by `pay_storage_miners`.
-		type MinerRanking: StorageMinerRanking<Self::AccountId>;
+		/// Weighted storage miners paid by `pay_storage_miners`.
+		type StorageMinerWeights: StorageMinerWeights<Self::AccountId>;
 
-		/// Most ranked miners a single `pay_storage_miners` call will pay.
+		/// Most storage miners a single `pay_storage_miners` call will pay.
 		#[pallet::constant]
 		type MaxMinersPerPayout: Get<u32>;
 
@@ -310,7 +337,7 @@ pub mod pallet {
 		RequesterCapRemoved { who: T::AccountId },
 		/// Distribution enabled/disabled status changed.
 		DistributionEnabledChanged { enabled: bool },
-		/// `pay_storage_miners` distributed emission pro-rata by ranking weight.
+		/// `pay_storage_miners` distributed emission pro-rata by family weight.
 		/// `paid < requested` when shares rounded to zero or a transfer was
 		/// skipped; the difference stays in the emission compartment.
 		StorageMinersPaid {
@@ -478,12 +505,14 @@ pub mod pallet {
 		}
 
 		/// Distribute `amount` from the bank's emission compartment to storage
-		/// miners, pro-rata to their current ranking weight.
+		/// miners, pro-rata to their weight.
 		///
-		/// Callable only by whitelisted callers. The runtime's `MinerRanking`
-		/// trait implementation must filter out validators and uid 238 from
-		/// the returned miner list. Floor-division dust and skipped shares
-		/// stay in the compartment.
+		/// Callable only by whitelisted callers. The runtime's
+		/// `StorageMinerWeights` implementation decides who is eligible, which
+		/// account each payee is paid at, and what that payee's weight is —
+		/// in production, an Arion family and the summed node weight of its
+		/// eligible children. Floor-division dust and skipped shares stay in
+		/// the compartment.
 		#[pallet::call_index(8)]
 		#[pallet::weight(<T as Config>::WeightInfo::pay_storage_miners(T::MaxMinersPerPayout::get()))]
 		pub fn pay_storage_miners(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
@@ -522,12 +551,19 @@ pub mod pallet {
 			// consumer overdrew, or the ED cushion); never overdraw the account.
 			ensure!(amount <= Self::available_for_payout(), Error::<T>::InsufficientBankBalance);
 
-			let miners = T::MinerRanking::active_storage_miners();
+			let miners = T::StorageMinerWeights::active_storage_miners();
 			ensure!(
 				u32::try_from(miners.len()).unwrap_or(u32::MAX) <= T::MaxMinersPerPayout::get(),
 				Error::<T>::TooManyMiners
 			);
-			let total_weight: u128 = miners.iter().map(|(_, w)| u128::from(*w)).sum();
+			// `saturating_add`, not `sum()`: a plain sum would panic in debug
+			// and wrap in release on an overflowing weight set. Saturating can
+			// only ever make the denominator too *small* — which the trait's
+			// caller contract forbids the source from producing — while
+			// wrapping could make it arbitrarily small and hand out shares
+			// that overdraw the compartment.
+			let total_weight: u128 =
+				miners.iter().fold(0u128, |acc, (_, w)| acc.saturating_add(*w));
 			ensure!(total_weight > 0, Error::<T>::NoEligibleMiners);
 
 			let bank = Self::account_id();
@@ -538,9 +574,7 @@ pub mod pallet {
 
 			for (owner, weight) in miners {
 				let share: BalanceOf<T> =
-					payment_math::weight_share(pool, u128::from(weight), total_weight)
-						.get()
-						.saturated_into();
+					payment_math::weight_share(pool, weight, total_weight).get().saturated_into();
 				// Zero shares (weight rounds below one planck) and failed
 				// transfers (e.g. a reaped owner account below its ED) are
 				// skipped, not fatal: their share stays in the compartment.

--- a/pallets/hippocampus/src/lib.rs
+++ b/pallets/hippocampus/src/lib.rs
@@ -395,6 +395,11 @@ pub mod pallet {
 		InsufficientComputeEmissionFunds,
 		/// The weighted compute-miner list exceeds `MaxComputeMinersPerPayout`.
 		TooManyComputeMiners,
+		/// The weight source returned a set whose weights sum past `u128`.
+		/// Both payouts reject rather than settle: a saturated denominator
+		/// inflates every pro-rata share and can overdraw the compartment.
+		/// Appended last on purpose — `Error` variants are metadata-indexed.
+		WeightSumOverflow,
 		/// No compute miner carries a non-zero weight this window.
 		NoEligibleComputeMiners,
 		/// This compute epoch has already been settled. Re-paying it would
@@ -556,14 +561,20 @@ pub mod pallet {
 				u32::try_from(miners.len()).unwrap_or(u32::MAX) <= T::MaxMinersPerPayout::get(),
 				Error::<T>::TooManyMiners
 			);
-			// `saturating_add`, not `sum()`: a plain sum would panic in debug
-			// and wrap in release on an overflowing weight set. Saturating can
-			// only ever make the denominator too *small* — which the trait's
-			// caller contract forbids the source from producing — while
-			// wrapping could make it arbitrarily small and hand out shares
-			// that overdraw the compartment.
-			let total_weight: u128 =
-				miners.iter().fold(0u128, |acc, (_, w)| acc.saturating_add(*w));
+			// `checked_add`, not `sum()` and not `saturating_add`. A plain sum
+			// wraps in release; saturating clamps. BOTH produce a denominator
+			// that is too *small*, and a small denominator inflates every
+			// pro-rata share — `weight_share` caps one share at the pool, but
+			// nothing caps their sum, and the compartment guards above were
+			// checked once against `amount` before this loop. Two entries at
+			// `u128::MAX` saturate to `u128::MAX` and then pay each of them
+			// the FULL requested amount, walking other compartments' funds out
+			// of the bank booked as emission. The trait forbids such a set;
+			// this refuses to settle one rather than trusting the contract.
+			let total_weight: u128 = miners
+				.iter()
+				.try_fold(0u128, |acc, (_, w)| acc.checked_add(*w))
+				.ok_or(Error::<T>::WeightSumOverflow)?;
 			ensure!(total_weight > 0, Error::<T>::NoEligibleMiners);
 
 			let bank = Self::account_id();
@@ -695,13 +706,15 @@ pub mod pallet {
 			// `MaxMinerStatusUpdatesPerCall` entries exist per epoch —
 			// a ceiling ~17 orders of magnitude below `u128::MAX`.
 			//
-			// That margin lives in ANOTHER pallet's constant. Anything that
-			// raises `MaxEpochWeightPerNode` toward `u128::MAX`, or a
-			// `ComputeMinerWeights` implementation that does not inherit that
-			// per-entry cap, must re-establish the bound here first — e.g. by
-			// rejecting a fold that saturates.
-			let total_weight: u128 =
-				miners.iter().fold(0u128, |acc, (_, w)| acc.saturating_add(*w));
+			// That margin lives in ANOTHER pallet's constant. Rather than trust
+			// it, the fold refuses to settle a set that overruns `u128` at all
+			// — so raising `MaxEpochWeightPerNode`, or supplying a
+			// `ComputeMinerWeights` implementation that does not inherit the
+			// per-entry cap, fails the payout instead of silently overdrawing.
+			let total_weight: u128 = miners
+				.iter()
+				.try_fold(0u128, |acc, (_, w)| acc.checked_add(*w))
+				.ok_or(Error::<T>::WeightSumOverflow)?;
 			ensure!(total_weight > 0, Error::<T>::NoEligibleComputeMiners);
 
 			let bank = Self::account_id();

--- a/pallets/hippocampus/src/mock.rs
+++ b/pallets/hippocampus/src/mock.rs
@@ -49,7 +49,7 @@ parameter_types! {
 }
 
 thread_local! {
-	static RANKED_MINERS: RefCell<Vec<(AccountId, u16)>> = const { RefCell::new(Vec::new()) };
+	static STORAGE_MINERS: RefCell<Vec<(AccountId, u128)>> = const { RefCell::new(Vec::new()) };
 	static COMPUTE_MINERS: RefCell<Vec<(AccountId, u128)>> = const { RefCell::new(Vec::new()) };
 	/// Epoch the mock weight set belongs to. Defaults to `None` so the tests
 	/// that predate the replay guard keep exercising a source with no
@@ -57,9 +57,12 @@ thread_local! {
 	static COMPUTE_EPOCH: RefCell<Option<u64>> = const { RefCell::new(None) };
 }
 
-/// Test control for the ranked-miner set `pay_storage_miners` reads.
-pub fn set_ranked_miners(miners: Vec<(AccountId, u16)>) {
-	RANKED_MINERS.with(|m| *m.borrow_mut() = miners);
+/// Test control for the weighted storage-miner set `pay_storage_miners` reads.
+///
+/// In production these are Arion families and their summed child weights; the
+/// mock stands in for `pallet_arion::Pallet::active_family_weights`.
+pub fn set_storage_miners(miners: Vec<(AccountId, u128)>) {
+	STORAGE_MINERS.with(|m| *m.borrow_mut() = miners);
 }
 
 /// Whitelist an account to call `pay_storage_miners`.
@@ -72,10 +75,10 @@ pub fn set_compute_miners(miners: Vec<(AccountId, u128)>) {
 	COMPUTE_MINERS.with(|m| *m.borrow_mut() = miners);
 }
 
-pub struct MockRanking;
-impl pallet_hippocampus::StorageMinerRanking<AccountId> for MockRanking {
-	fn active_storage_miners() -> Vec<(AccountId, u16)> {
-		RANKED_MINERS.with(|m| m.borrow().clone())
+pub struct MockStorageWeights;
+impl pallet_hippocampus::StorageMinerWeights<AccountId> for MockStorageWeights {
+	fn active_storage_miners() -> Vec<(AccountId, u128)> {
+		STORAGE_MINERS.with(|m| m.borrow().clone())
 	}
 }
 
@@ -108,7 +111,7 @@ impl pallet_hippocampus::Config for Test {
 	type Currency = Balances;
 	type PalletId = HippocampusPalletId;
 	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
-	type MinerRanking = MockRanking;
+	type StorageMinerWeights = MockStorageWeights;
 	type MaxMinersPerPayout = ConstU32<16>;
 	type BlocksPer24Hours = BlocksPer24Hours;
 	type Max24HourMinerPayout = Max24HourMinerPayout;
@@ -148,7 +151,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut ext = sp_io::TestExternalities::new(t);
 	ext.execute_with(|| {
 		System::set_block_number(1);
-		set_ranked_miners(Vec::new());
+		set_storage_miners(Vec::new());
 		set_compute_miners(Vec::new());
 	});
 	ext

--- a/pallets/hippocampus/src/tests.rs
+++ b/pallets/hippocampus/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-	mock::*, ComputeEmissionPaidOut, DepositType, EmissionPaidOut, Error, Event, LastPaidComputeEpoch,
-	MinerPaymentWhitelist, TotalDeposited, TotalPaidByRequester, TotalPaidOut,
+	mock::*, ComputeEmissionPaidOut, DepositType, EmissionPaidOut, Error, Event,
+	LastPaidComputeEpoch, MinerPaymentWhitelist, TotalDeposited, TotalPaidByRequester,
+	TotalPaidOut,
 };
 use frame_support::{assert_noop, assert_ok};
 
@@ -243,7 +244,7 @@ fn pay_storage_miners_distributes_pro_rata() {
 			1_000,
 			DepositType::Emission
 		));
-		set_ranked_miners(vec![(charlie(), 1), (dave(), 3)]);
+		set_storage_miners(vec![(charlie(), 1), (dave(), 3)]);
 		whitelist_miner_payment_caller(alice());
 
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 1_000));
@@ -279,6 +280,116 @@ fn pay_storage_miners_distributes_pro_rata() {
 }
 
 #[test]
+fn pay_storage_miners_pays_every_family_by_summed_child_weight() {
+	// The regression this payout source exists for: families with real weight
+	// were receiving nothing because the payee set came from the ranking
+	// pallet, which Arion operators do not appear in. Every family the source
+	// returns must be paid, and paid in proportion to its summed child weight.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::Emission
+		));
+		// Family weights as Arion aggregates them: charlie runs three nodes at
+		// 50_000, dave one. Both are far past u16::MAX territory in total.
+		set_storage_miners(vec![(charlie(), 150_000), (dave(), 50_000)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 10_000));
+
+		// 3:1 on summed weight, and nobody eligible is left out.
+		assert_eq!(Balances::free_balance(charlie()), 7_500);
+		assert_eq!(Balances::free_balance(dave()), 2_500);
+		System::assert_last_event(
+			Event::StorageMinersPaid {
+				requested: 10_000,
+				paid: 10_000,
+				miners_paid: 2,
+				miners_skipped: 0,
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn pay_storage_miners_ranks_families_by_weight_not_by_node_count() {
+	// dave runs more nodes than charlie but carries less total weight, so
+	// dave is paid less: the share follows the summed weight, which is what
+	// "largest family gets the biggest share" has to mean once families run
+	// different numbers of differently-weighted nodes.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::Emission
+		));
+		// charlie: 1 node at 40_000. dave: 4 nodes at 2_500 = 10_000.
+		set_storage_miners(vec![(charlie(), 40_000), (dave(), 10_000)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 10_000));
+
+		assert_eq!(Balances::free_balance(charlie()), 8_000);
+		assert_eq!(Balances::free_balance(dave()), 2_000);
+		assert!(Balances::free_balance(charlie()) > Balances::free_balance(dave()));
+	});
+}
+
+#[test]
+fn pay_storage_miners_handles_wide_u128_family_weights() {
+	// A u16 accumulator would have clamped both families to 65_535 and split
+	// this payout 50/50. The u128 widening is what keeps the 4:1 real.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::Emission
+		));
+		// 35 children at MaxNodeWeight (the runtime's per-family ceiling) vs a
+		// quarter of that — both above u16::MAX.
+		let big = 1_750_000u128;
+		let small = big / 4;
+		assert!(small > u128::from(u16::MAX));
+		set_storage_miners(vec![(charlie(), big), (dave(), small)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 10_000));
+
+		assert_eq!(Balances::free_balance(charlie()), 8_000);
+		assert_eq!(Balances::free_balance(dave()), 2_000);
+	});
+}
+
+#[test]
+fn pay_storage_miners_never_overdraws_on_a_saturating_weight_sum() {
+	// The trait forbids a weight set whose sum saturates u128, but if one ever
+	// arrives the bank must still not pay out more than it was asked for —
+	// `saturating_add` shrinks the denominator, which inflates every share.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::Emission
+		));
+		set_storage_miners(vec![(charlie(), u128::MAX), (dave(), u128::MAX)]);
+		whitelist_miner_payment_caller(alice());
+
+		let bank_before = Balances::free_balance(hippocampus_account());
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 10_000));
+
+		let paid = bank_before - Balances::free_balance(hippocampus_account());
+		assert!(paid <= 10_000, "payout {paid} exceeded the requested 10_000");
+		assert_eq!(EmissionPaidOut::<Test>::get(), paid);
+	});
+}
+
+#[test]
 fn pay_storage_miners_skips_failed_transfers() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
@@ -290,7 +401,7 @@ fn pay_storage_miners_skips_failed_transfers() {
 		// charlie's share (101 * 1/20 = 5) is below the ED of 10 and charlie
 		// holds no account, so the transfer itself fails and is skipped;
 		// dave's share (95) clears the ED and pays out.
-		set_ranked_miners(vec![(charlie(), 1), (dave(), 19)]);
+		set_storage_miners(vec![(charlie(), 1), (dave(), 19)]);
 		whitelist_miner_payment_caller(alice());
 
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 101));
@@ -318,13 +429,16 @@ fn pay_storage_miners_conserves_every_planck() {
 	// Invariant sweep: whatever the weight vector, exactly `paid` leaves the
 	// bank, all of it lands with miners, both ledgers book the same figure,
 	// and floor-division dust is bounded by one planck per miner.
-	let cases: &[(&[u16], u128)] = &[
+	let cases: &[(&[u128], u128)] = &[
 		(&[1, 3], 1_000),
 		(&[7, 7, 7], 1_000),
 		(&[1, 65_535], 9_999),
 		(&[13, 29, 58], 101),
 		(&[5], 10),
 		(&[1, 2, 3, 4, 5, 6, 7], 9_973),
+		// Family-scale totals: sums of 35 children at MaxNodeWeight, i.e.
+		// well past what a u16 weight could have carried.
+		(&[1_750_000, 250_000], 9_973),
 	];
 	for (weights, amount) in cases {
 		new_test_ext().execute_with(|| {
@@ -338,7 +452,7 @@ fn pay_storage_miners_conserves_every_planck() {
 				10_000,
 				DepositType::Emission
 			));
-			let miners: Vec<(AccountId, u16)> = weights
+			let miners: Vec<(AccountId, u128)> = weights
 				.iter()
 				.enumerate()
 				.map(|(i, w)| {
@@ -346,7 +460,7 @@ fn pay_storage_miners_conserves_every_planck() {
 					(sp_runtime::AccountId32::new([100 + index; 32]), *w)
 				})
 				.collect();
-			set_ranked_miners(miners.clone());
+			set_storage_miners(miners.clone());
 			whitelist_miner_payment_caller(alice());
 
 			let bank_before = Balances::free_balance(hippocampus_account());
@@ -397,7 +511,7 @@ fn pay_storage_miners_respects_distribution_switch() {
 			1_000,
 			DepositType::Emission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		whitelist_miner_payment_caller(alice());
 		assert_ok!(Hippocampus::set_distribution_enabled(RuntimeOrigin::root(), false));
 		assert_noop!(
@@ -417,7 +531,7 @@ fn pay_storage_miners_cannot_spend_other_compartments() {
 			1_000,
 			DepositType::MarketplaceRevenue
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		whitelist_miner_payment_caller(alice());
 		assert_noop!(
 			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 100),
@@ -438,7 +552,7 @@ fn pay_storage_miners_cannot_overdraw_the_bank() {
 		));
 		assert_ok!(Hippocampus::add_requester(RuntimeOrigin::root(), bob()));
 		assert_ok!(Hippocampus::request_payment(&bob(), &charlie(), 600));
-		set_ranked_miners(vec![(dave(), 1)]);
+		set_storage_miners(vec![(dave(), 1)]);
 		whitelist_miner_payment_caller(alice());
 		assert_noop!(
 			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 1_000),
@@ -448,7 +562,7 @@ fn pay_storage_miners_cannot_overdraw_the_bank() {
 }
 
 #[test]
-fn pay_storage_miners_rejects_empty_or_zero_weight_ranking() {
+fn pay_storage_miners_rejects_empty_or_zero_weight_sources() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
 		assert_ok!(Hippocampus::deposit(
@@ -461,7 +575,7 @@ fn pay_storage_miners_rejects_empty_or_zero_weight_ranking() {
 			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 100),
 			Error::<Test>::NoEligibleMiners
 		);
-		set_ranked_miners(vec![(charlie(), 0), (dave(), 0)]);
+		set_storage_miners(vec![(charlie(), 0), (dave(), 0)]);
 		whitelist_miner_payment_caller(alice());
 		assert_noop!(
 			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 100),
@@ -481,8 +595,8 @@ fn pay_storage_miners_bounds_the_miner_list() {
 		));
 		// MaxMinersPerPayout is 16 in the mock; 17 entries must reject.
 		let miners: Vec<_> =
-			(1u8..=17).map(|i| (sp_runtime::AccountId32::new([i; 32]), 1u16)).collect();
-		set_ranked_miners(miners);
+			(1u8..=17).map(|i| (sp_runtime::AccountId32::new([i; 32]), 1u128)).collect();
+		set_storage_miners(miners);
 		whitelist_miner_payment_caller(alice());
 		assert_noop!(
 			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 100),
@@ -500,7 +614,7 @@ fn pay_storage_miners_dust_stays_in_compartment() {
 			1_000,
 			DepositType::Emission
 		));
-		set_ranked_miners(vec![(charlie(), 3), (dave(), 7)]);
+		set_storage_miners(vec![(charlie(), 3), (dave(), 7)]);
 		whitelist_miner_payment_caller(alice());
 
 		// 101 * 3/10 = 30, 101 * 7/10 = 70 — one planck of dust remains.
@@ -532,7 +646,7 @@ fn pay_storage_miners_skips_zero_shares() {
 			DepositType::Emission
 		));
 		// 10_000 * 1/65_536 floors to zero: charlie is skipped, not fatal.
-		set_ranked_miners(vec![(charlie(), 1), (dave(), 65_535)]);
+		set_storage_miners(vec![(charlie(), 1), (dave(), 65_535)]);
 		whitelist_miner_payment_caller(alice());
 
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 10_000));
@@ -560,7 +674,7 @@ fn pay_storage_miners_compartment_is_cumulative() {
 			1_000,
 			DepositType::Emission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		whitelist_miner_payment_caller(alice());
 
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 600));
@@ -589,7 +703,7 @@ fn pay_storage_miners_respects_24hour_cap() {
 			cap * 2,
 			DepositType::Emission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		whitelist_miner_payment_caller(alice());
 
 		// A single request above the cap rejects outright.
@@ -667,7 +781,7 @@ fn pay_storage_miners_resets_24hour_period() {
 			cap * 2,
 			DepositType::Emission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		whitelist_miner_payment_caller(alice());
 
 		// Exhaust the whole 24-hour budget; the next planck rejects.
@@ -748,7 +862,7 @@ fn pay_compute_miners_distributes_pro_rata() {
 
 #[test]
 fn pay_compute_miners_handles_wide_u128_weights() {
-	// The compute weights are u128, not the storage ranking's u16 — a realistic
+	// A realistic
 	// `EpochWeights` pair near `MaxEpochWeightPerNode` (u64::MAX) must still
 	// split cleanly and never overflow the wide intermediate.
 	new_test_ext().execute_with(|| {
@@ -983,7 +1097,7 @@ fn pay_storage_miners_cannot_spend_the_compute_compartment() {
 			1_000,
 			DepositType::ComputeEmission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		whitelist_miner_payment_caller(alice());
 		assert_noop!(
 			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 100),
@@ -1008,7 +1122,7 @@ fn the_two_compartments_are_independently_spendable() {
 			1_000,
 			DepositType::ComputeEmission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		set_compute_miners(vec![(dave(), 1)]);
 		whitelist_miner_payment_caller(alice());
 
@@ -1164,7 +1278,7 @@ fn the_24hour_budget_is_shared_across_both_payouts() {
 			cap,
 			DepositType::ComputeEmission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		set_compute_miners(vec![(dave(), 1)]);
 		whitelist_miner_payment_caller(alice());
 
@@ -1218,7 +1332,7 @@ fn the_shared_24hour_period_resets_once_for_both_payouts() {
 			cap,
 			DepositType::ComputeEmission
 		));
-		set_ranked_miners(vec![(charlie(), 1)]);
+		set_storage_miners(vec![(charlie(), 1)]);
 		set_compute_miners(vec![(dave(), 1)]);
 		whitelist_miner_payment_caller(alice());
 

--- a/pallets/hippocampus/src/tests.rs
+++ b/pallets/hippocampus/src/tests.rs
@@ -366,10 +366,19 @@ fn pay_storage_miners_handles_wide_u128_family_weights() {
 }
 
 #[test]
-fn pay_storage_miners_never_overdraws_on_a_saturating_weight_sum() {
-	// The trait forbids a weight set whose sum saturates u128, but if one ever
-	// arrives the bank must still not pay out more than it was asked for —
-	// `saturating_add` shrinks the denominator, which inflates every share.
+fn pay_storage_miners_rejects_a_weight_set_that_overruns_u128() {
+	// A denominator that saturates is SMALLER than the true total, and a small
+	// denominator inflates every pro-rata share: two payees at `u128::MAX`
+	// each compute a share of the whole pool. The bank must refuse the set
+	// outright, because the compartment guards ran once against `amount`
+	// before the transfer loop and nothing caps the running total.
+	//
+	// The bank is funded well past the requested amount ON PURPOSE, and from a
+	// second compartment. An under-funded bank makes this test pass for the
+	// wrong reason — the second transfer fails on insufficient balance and is
+	// booked as `miners_skipped`, so the payout looks conserved when it is
+	// only broke. That is exactly how the original version of this test
+	// passed against unguarded code.
 	new_test_ext().execute_with(|| {
 		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
 		assert_ok!(Hippocampus::deposit(
@@ -377,7 +386,41 @@ fn pay_storage_miners_never_overdraws_on_a_saturating_weight_sum() {
 			10_000,
 			DepositType::Emission
 		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			100_000,
+			DepositType::MarketplaceRevenue
+		));
 		set_storage_miners(vec![(charlie(), u128::MAX), (dave(), u128::MAX)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_noop!(
+			Hippocampus::pay_storage_miners(RuntimeOrigin::signed(alice()), 10_000),
+			Error::<Test>::WeightSumOverflow
+		);
+		// Nothing moved and no ledger advanced.
+		assert_eq!(Balances::free_balance(charlie()), 0);
+		assert_eq!(Balances::free_balance(dave()), 0);
+		assert_eq!(EmissionPaidOut::<Test>::get(), 0);
+		assert_eq!(Hippocampus::emission_available(), 10_000);
+	});
+}
+
+#[test]
+fn a_weight_set_at_the_u128_ceiling_still_settles() {
+	// The guard rejects an overrun, not a large-but-representable total: a set
+	// summing to exactly `u128::MAX` must still pay. Otherwise the fix trades
+	// an overdraw for a payout that can never settle.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::Emission
+		));
+		let half = u128::MAX / 2;
+		// half + (half + 1) == u128::MAX exactly.
+		set_storage_miners(vec![(charlie(), half), (dave(), half + 1)]);
 		whitelist_miner_payment_caller(alice());
 
 		let bank_before = Balances::free_balance(hippocampus_account());
@@ -386,6 +429,36 @@ fn pay_storage_miners_never_overdraws_on_a_saturating_weight_sum() {
 		let paid = bank_before - Balances::free_balance(hippocampus_account());
 		assert!(paid <= 10_000, "payout {paid} exceeded the requested 10_000");
 		assert_eq!(EmissionPaidOut::<Test>::get(), paid);
+	});
+}
+
+#[test]
+fn pay_compute_miners_rejects_a_weight_set_that_overruns_u128() {
+	// Same guard on the compute compartment, and the same funding trap: the
+	// bank holds far more than the request so a rejected set cannot be
+	// confused with a bank that simply ran out.
+	new_test_ext().execute_with(|| {
+		assert_ok!(Hippocampus::deposit(RuntimeOrigin::signed(alice()), 10, DepositType::Grant));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			10_000,
+			DepositType::ComputeEmission
+		));
+		assert_ok!(Hippocampus::deposit(
+			RuntimeOrigin::signed(alice()),
+			100_000,
+			DepositType::MarketplaceRevenue
+		));
+		set_compute_miners(vec![(charlie(), u128::MAX), (dave(), u128::MAX)]);
+		whitelist_miner_payment_caller(alice());
+
+		assert_noop!(
+			Hippocampus::pay_compute_miners(RuntimeOrigin::signed(alice()), 10_000),
+			Error::<Test>::WeightSumOverflow
+		);
+		assert_eq!(Balances::free_balance(charlie()), 0);
+		assert_eq!(ComputeEmissionPaidOut::<Test>::get(), 0);
+		assert_eq!(Hippocampus::compute_emission_available(), 10_000);
 	});
 }
 

--- a/pallets/hippocampus/src/weights.rs
+++ b/pallets/hippocampus/src/weights.rs
@@ -15,11 +15,14 @@ use sp_std::marker::PhantomData;
 /// Reads `pay_storage_miners` spends assembling its payee set from the Arion
 /// pallet, before it pays anybody.
 ///
-/// Sized off the mainnet registration caps: `MaxFamilies` (600) map keys, plus
-/// three reads (`ChildRegistrations`, `NodeWeightLastBucket`,
-/// `NodeWeightByChild`) for each of at most `MaxChildrenTotal` (1_000)
-/// children across all families.
-const SOURCE_SCAN_READS: u64 = 600 + 3 * 1_000;
+/// Sized off `MaxChildrenTotal` (1_000): a `FamilyChildren` key exists only
+/// while a family has at least one Active child (the key is removed at zero by
+/// `cleanup_family_when_no_active_children`), so the number of scanned family
+/// keys is bounded by the active-child cap, not by `MaxFamilies` (600) — same
+/// reasoning that sizes `MaxMinersPerPayout` in the mainnet runtime. On top of
+/// those keys, three reads (`ChildRegistrations`, `NodeWeightLastBucket`,
+/// `NodeWeightByChild`) for each of at most `MaxChildrenTotal` children.
+const SOURCE_SCAN_READS: u64 = 1_000 + 3 * 1_000;
 
 pub trait WeightInfo {
 	fn deposit() -> Weight;

--- a/pallets/hippocampus/src/weights.rs
+++ b/pallets/hippocampus/src/weights.rs
@@ -12,6 +12,15 @@ use frame_support::{
 };
 use sp_std::marker::PhantomData;
 
+/// Reads `pay_storage_miners` spends assembling its payee set from the Arion
+/// pallet, before it pays anybody.
+///
+/// Sized off the mainnet registration caps: `MaxFamilies` (600) map keys, plus
+/// three reads (`ChildRegistrations`, `NodeWeightLastBucket`,
+/// `NodeWeightByChild`) for each of at most `MaxChildrenTotal` (1_000)
+/// children across all families.
+const SOURCE_SCAN_READS: u64 = 600 + 3 * 1_000;
+
 pub trait WeightInfo {
 	fn deposit() -> Weight;
 	fn add_requester() -> Weight;
@@ -45,8 +54,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn pay_storage_miners(n: u32) -> Weight {
 		// Guards + compartment/ledger bookkeeping, then one transfer
 		// (2 account reads/writes) per miner.
+		//
+		// `SOURCE_SCAN_READS` covers building the payee set, which the
+		// per-miner term does not: the Arion source walks `FamilyChildren`
+		// (<= `MaxFamilies` keys) and reads registration, freshness, and
+		// weight for each child (<= `MaxChildrenTotal` x 3 network-wide). It
+		// is a flat term because the walk is bounded by those registration
+		// caps, not by `n`. Revisit if the runtime raises them.
 		Weight::from_parts(30_000_000, 0)
-			.saturating_add(T::DbWeight::get().reads(5_u64))
+			.saturating_add(T::DbWeight::get().reads(5_u64 + SOURCE_SCAN_READS))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 			.saturating_add(
 				Weight::from_parts(50_000_000, 0)
@@ -90,7 +106,7 @@ impl WeightInfo for () {
 
 	fn pay_storage_miners(n: u32) -> Weight {
 		Weight::from_parts(30_000_000, 0)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
+			.saturating_add(RocksDbWeight::get().reads(5_u64 + SOURCE_SCAN_READS))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 			.saturating_add(
 				Weight::from_parts(50_000_000, 0)

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -481,7 +481,19 @@ impl pallet_hippocampus::Config for Runtime {
 	type PalletId = HippocampusPalletId;
 	type AdminOrigin = frame_system::EnsureSignedBy<ArionAdminMembers, AccountId>;
 	type StorageMinerWeights = ArionFamilyWeightsSource;
-	type MaxMinersPerPayout = ConstU32<512>;
+	// Payees are Arion families, not ranked nodes. Every family in the payout
+	// set has at least one Active child, and `register_child` caps
+	// `TotalActiveChildren` at `MaxChildrenTotal` (1_000), so at most 1_000
+	// families can ever carry weight. Keep this ABOVE that — if the family
+	// count passes this constant, every `pay_storage_miners` call fails with
+	// `TooManyMiners` and no storage emission can be paid at all, with each
+	// missed day unrecoverable under the 24-hour cap.
+	//
+	// NOT sized off `MaxFamilies` (600): that cap is only enforced when a
+	// family claims its FIRST fee-free slot, and `FamilyCount` is decremented
+	// on cleanup without being re-incremented on re-registration, so it does
+	// not bound the number of distinct families. `MaxChildrenTotal` does.
+	type MaxMinersPerPayout = ConstU32<1024>;
 	type BlocksPer24Hours = BlocksPer24Hours;
 	type Max24HourMinerPayout = Max24HourMinerPayout;
 	type ComputeMinerWeights = ComputeMinerWeightsSource;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -163,33 +163,37 @@ impl pallet_arion::PayoutSource<AccountId, Balance> for ArionPayoutSource {
 	}
 }
 
-/// Adapter: `pay_storage_miners` reads the storage-miner ranking
-/// (`RankingStorage`, instance 1) and pays each node's registered owner.
-pub struct StorageMinerRankingSource;
-impl pallet_hippocampus::StorageMinerRanking<AccountId> for StorageMinerRankingSource {
-	fn active_storage_miners() -> Vec<(AccountId, u16)> {
-		// Get uid 238's account if it exists
+/// Adapter: `pay_storage_miners` reads the **Arion** pallet — its family/child
+/// registry and its validator-reported node weights — and pays each family.
+///
+/// NOT `RankingStorage`. The ranking pallet is a separate, storage-node-keyed
+/// leaderboard that Arion operators do not appear in: paying from it left
+/// registered Arion families with real weight receiving nothing at all, which
+/// is the bug this adapter exists to fix. Arion is where a storage miner
+/// registers, where its deposit is locked, and where its weight is reported,
+/// so it is also where the payout set comes from.
+///
+/// The payee is the **family** (the operator account that put up the child
+/// deposits), not a child node account, and the family's weight is the sum of
+/// its eligible children's `NodeWeightByChild` — so a family's share of a
+/// payout is its summed node weight over the network's, and the family
+/// carrying the most weight is paid the most. Eligibility (Active
+/// registration + a non-stale weight) and the aggregation live in
+/// `pallet_arion::Pallet::active_family_weights`, which also guarantees the
+/// bank's "one payee, one entry" contract: `FamilyChildren` is keyed by
+/// family, so no family can appear twice.
+pub struct ArionFamilyWeightsSource;
+impl pallet_hippocampus::StorageMinerWeights<AccountId> for ArionFamilyWeightsSource {
+	fn active_storage_miners() -> Vec<(AccountId, u128)> {
+		// Carried over from the ranking-based adapter: uid 238 is excluded
+		// from emission by operator decision. Kept source-independent — it
+		// now only bites if that account is itself a registered Arion family.
 		let uid_238_account =
 			pallet_metagraph::Pallet::<Runtime>::get_uid_item(238).map(|uid| uid.substrate_address);
 
-		pallet_rankings::Pallet::<Runtime>::get_ranked_list()
+		pallet_arion::Pallet::<Runtime>::active_family_weights()
 			.into_iter()
-			.filter(|node| {
-				node.is_active && node.node_type == pallet_registration::NodeType::StorageMiner
-			})
-			.filter_map(|node| {
-				pallet_registration::Pallet::<Runtime>::get_registered_node(node.node_id.clone())
-					.ok()
-					.map(|info| (info.owner, node.weight))
-			})
-			// Filter out uid 238's account (already filtered to StorageMiner type by ranking)
-			.filter(|(owner, _)| {
-				if let Some(uid_238_acc) = &uid_238_account {
-					owner != uid_238_acc
-				} else {
-					true
-				}
-			})
+			.filter(|(family, _)| Some(family) != uid_238_account.as_ref())
 			.collect()
 	}
 }
@@ -476,7 +480,7 @@ impl pallet_hippocampus::Config for Runtime {
 	type Currency = Balances;
 	type PalletId = HippocampusPalletId;
 	type AdminOrigin = frame_system::EnsureSignedBy<ArionAdminMembers, AccountId>;
-	type MinerRanking = StorageMinerRankingSource;
+	type StorageMinerWeights = ArionFamilyWeightsSource;
 	type MaxMinersPerPayout = ConstU32<512>;
 	type BlocksPer24Hours = BlocksPer24Hours;
 	type Max24HourMinerPayout = Max24HourMinerPayout;
@@ -576,7 +580,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("hippius"),
 	impl_name: create_runtime_str!("hippius"),
 	authoring_version: 1,
-	spec_version: 92006,
+	spec_version: 92007,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/mainnet/tests/pay_compute_miners.rs
+++ b/runtime/mainnet/tests/pay_compute_miners.rs
@@ -13,7 +13,6 @@ use hippius_mainnet_runtime::{
 use pallet_arion::PayoutSource;
 use pallet_compute_scoring::{ChildRegistration, ChildStatus};
 use pallet_hippocampus::{ComputeMinerWeights, DepositType};
-use pallet_registration::{ColdkeyNodeInfoLite, NodeType, Status};
 use sp_core::crypto::Ss58Codec;
 use sp_runtime::{AccountId32, BuildStorage};
 
@@ -166,31 +165,34 @@ fn the_same_epoch_cannot_be_paid_twice() {
 	});
 }
 
-/// Register a storage-miner node and append it to the ranked list — needed
-/// only to prove the shared 24-hour budget spans both payouts.
-fn seed_ranked_storage_miner(node_seed: u8, owner: &AccountId, weight: u16, is_active: bool) {
-	let node_id = vec![node_seed; 32];
-	pallet_registration::ColdkeyNodeRegistrationV2::<Runtime>::insert(
-		node_id.clone(),
-		Some(ColdkeyNodeInfoLite {
-			node_id: node_id.clone(),
-			node_type: NodeType::StorageMiner,
-			status: Status::Online,
-			registered_at: 0u32.into(),
-			owner: owner.clone(),
-		}),
+/// Register an Arion storage family with one weighted child — needed only to
+/// prove the shared 24-hour budget spans both payouts.
+///
+/// `pay_storage_miners` reads Arion (`FamilyChildren` + `NodeWeightByChild`),
+/// not the ranking pallet, so seeding a ranked node here would leave the
+/// storage payout with no eligible miners.
+fn seed_arion_storage_family(family: &AccountId, child: &AccountId, weight: u16) {
+	let node_id: [u8; 32] = child.clone().into();
+	pallet_arion::ChildRegistrations::<Runtime>::insert(
+		child,
+		pallet_arion::ChildRegistration {
+			family: family.clone(),
+			node_id,
+			status: pallet_arion::ChildStatus::Active,
+			deposit: 0u128,
+			unbonding_end: 0u32.into(),
+		},
 	);
-	let mut list = pallet_rankings::RankedList::<Runtime>::get();
-	list.push(pallet_rankings::NodeRankings {
-		rank: u32::from(node_seed),
-		node_id,
-		node_ss58_address: owner.to_ss58check().into_bytes(),
-		node_type: NodeType::StorageMiner,
-		weight,
-		last_updated: 0u32.into(),
-		is_active,
+	pallet_arion::FamilyChildren::<Runtime>::mutate(family, |v| {
+		v.try_push(child.clone()).expect("under MaxChildrenPerFamily");
 	});
-	pallet_rankings::RankedList::<Runtime>::put(list);
+	pallet_arion::FamilyActiveChildren::<Runtime>::mutate(family, |n| *n += 1);
+	// Reported in the current bucket, so the weight is fresh.
+	pallet_arion::NodeWeightByChild::<Runtime>::insert(child, weight);
+	pallet_arion::NodeWeightLastBucket::<Runtime>::insert(
+		child,
+		pallet_arion::CurrentWeightBucket::<Runtime>::get(),
+	);
 }
 
 /// Close of `epoch`: `vali_submit_epoch_close` sets `CurrentEpoch = epoch`
@@ -389,7 +391,7 @@ fn the_daily_cap_is_shared_with_storage_payouts() {
 	new_test_ext().execute_with(|| {
 		let cap = <Runtime as pallet_hippocampus::Config>::Max24HourMinerPayout::get();
 		let family_a = account(2);
-		let storage_miner = account(9);
+		let storage_family = account(9);
 		let funder = account(1);
 		Balances::make_free_balance_be(&funder, cap.saturating_mul(4));
 
@@ -411,13 +413,13 @@ fn the_daily_cap_is_shared_with_storage_payouts() {
 		));
 		assert_ok!(Hippocampus::add_miner_payment_caller(RuntimeOrigin::signed(admin()), admin()));
 
-		seed_ranked_storage_miner(30, &storage_miner, 100, true);
+		seed_arion_storage_family(&storage_family, &account(31), 100);
 		seed_compute_child(10, &family_a, &account(20), 7, 100, ChildStatus::Active);
 		close_epoch(7);
 
 		// Storage takes the whole day's budget.
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), cap));
-		assert_eq!(Balances::free_balance(&storage_miner), cap);
+		assert_eq!(Balances::free_balance(&storage_family), cap);
 
 		// Compute is rate-limited out even though its compartment is full.
 		assert_noop!(

--- a/runtime/mainnet/tests/pay_storage_miners.rs
+++ b/runtime/mainnet/tests/pay_storage_miners.rs
@@ -1,22 +1,33 @@
-//! End-to-end: emission deposited into the bank is distributed to ranked
-//! storage-miner owners by `pay_storage_miners`, the runtime's ranking
-//! source resolves owners and applies the uid-238/activity filters, and the
-//! emission compartment is invisible to the arion settlement headroom.
+//! End-to-end: emission deposited into the bank is distributed to **Arion
+//! families** by `pay_storage_miners`, each family's weight being the sum of
+//! the node weights of its eligible children; and the emission compartment is
+//! invisible to the arion settlement headroom.
+//!
+//! These tests read real Arion storage through the runtime's
+//! `ArionFamilyWeightsSource` adapter — the payout set is `FamilyChildren` +
+//! `NodeWeightByChild`, NOT `RankingStorage`. Paying from the ranking pallet
+//! was the production bug: Arion operators never appear in that leaderboard,
+//! so registered families carrying real weight received nothing.
 
-use frame_support::traits::{Currency, Get};
+use frame_support::traits::Currency;
 use frame_support::{assert_noop, assert_ok};
 use hippius_mainnet_runtime::{
 	AccountId, ArionPayoutSource, Balances, Hippocampus, Runtime, RuntimeOrigin, System,
 };
-use pallet_arion::PayoutSource;
+use pallet_arion::{
+	ChildRegistration, ChildRegistrations, ChildStatus, CurrentWeightBucket, FamilyActiveChildren,
+	FamilyChildren, NodeWeightByChild, NodeWeightLastBucket, PayoutSource,
+};
 use pallet_hippocampus::DepositType;
 use pallet_metagraph::{Role, UID};
-use pallet_registration::{ColdkeyNodeInfoLite, NodeType, Status};
 use sp_core::crypto::Ss58Codec;
 use sp_runtime::{AccountId32, BuildStorage};
 
 /// Must match `ExistentialDeposit` in the runtime.
 const ED: u128 = 500;
+
+/// Bucket every fresh weight is reported in.
+const BUCKET: u32 = 100;
 
 /// The hardcoded `ArionAdminMembers` account (all arion/bank admin origins).
 fn admin() -> AccountId {
@@ -27,38 +38,51 @@ fn account(seed: u8) -> AccountId {
 	AccountId32::new([seed; 32])
 }
 
+/// A child account distinct from any family account seed.
+fn child(seed: u8) -> AccountId {
+	let mut raw = [seed; 32];
+	raw[0] = 0xC0;
+	AccountId32::new(raw)
+}
+
 fn new_test_ext() -> sp_io::TestExternalities {
 	let t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
 	let mut ext = sp_io::TestExternalities::new(t);
-	ext.execute_with(|| System::set_block_number(1));
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		CurrentWeightBucket::<Runtime>::put(BUCKET);
+	});
 	ext
 }
 
-/// Register a storage-miner node and append it to the ranked list. Seeds
-/// storage directly, the same way miner_payments.rs seeds arion children.
-fn seed_ranked_storage_miner(node_seed: u8, owner: &AccountId, weight: u16, is_active: bool) {
-	let node_id = vec![node_seed; 32];
-	pallet_registration::ColdkeyNodeRegistrationV2::<Runtime>::insert(
-		node_id.clone(),
-		Some(ColdkeyNodeInfoLite {
-			node_id: node_id.clone(),
-			node_type: NodeType::StorageMiner,
-			status: Status::Online,
-			registered_at: 0u32.into(),
-			owner: owner.clone(),
-		}),
+/// Register `child` under `family` with the given status, and give it a node
+/// weight last reported `age` buckets ago. Seeds storage directly, the same
+/// way family_weight_aggregate.rs and miner_payments.rs do.
+fn seed_child(family: &AccountId, child: &AccountId, weight: u16, status: ChildStatus, age: u32) {
+	let node_id: [u8; 32] = child.clone().into();
+	ChildRegistrations::<Runtime>::insert(
+		child,
+		ChildRegistration {
+			family: family.clone(),
+			node_id,
+			status,
+			deposit: 0u128,
+			unbonding_end: 0u32.into(),
+		},
 	);
-	let mut list = pallet_rankings::RankedList::<Runtime>::get();
-	list.push(pallet_rankings::NodeRankings {
-		rank: u32::from(node_seed),
-		node_id,
-		node_ss58_address: owner.to_ss58check().into_bytes(),
-		node_type: NodeType::StorageMiner,
-		weight,
-		last_updated: 0u32.into(),
-		is_active,
+	FamilyChildren::<Runtime>::mutate(family, |v| {
+		v.try_push(child.clone()).expect("under MaxChildrenPerFamily");
 	});
-	pallet_rankings::RankedList::<Runtime>::put(list);
+	if status == ChildStatus::Active {
+		FamilyActiveChildren::<Runtime>::mutate(family, |n| *n += 1);
+	}
+	NodeWeightByChild::<Runtime>::insert(child, weight);
+	NodeWeightLastBucket::<Runtime>::insert(child, BUCKET.saturating_sub(age));
+}
+
+/// The common case: an Active child whose weight was reported this bucket.
+fn seed_active_child(family: &AccountId, child: &AccountId, weight: u16) {
+	seed_child(family, child, weight, ChildStatus::Active, 0);
 }
 
 /// Fund the bank with an ED cushion plus `emission` tagged as Emission, and
@@ -106,7 +130,7 @@ fn emission_compartment_invisible_to_arion_settlement() {
 }
 
 #[test]
-fn pay_storage_miners_with_empty_ranking() {
+fn pay_storage_miners_with_no_registered_families() {
 	new_test_ext().execute_with(|| {
 		fund_bank_and_whitelist_admin(100_000);
 
@@ -119,36 +143,202 @@ fn pay_storage_miners_with_empty_ranking() {
 }
 
 #[test]
-fn pay_storage_miners_distributes_to_ranked_miners() {
+fn pay_storage_miners_distributes_to_arion_families() {
+	// The regression test for the production bug: a family registered in Arion
+	// with weight on its children gets paid, and gets paid in proportion.
 	new_test_ext().execute_with(|| {
-		let (miner_a, miner_b, inactive) = (account(2), account(3), account(4));
+		let (fam_a, fam_b) = (account(2), account(3));
 		fund_bank_and_whitelist_admin(100_000);
 
-		seed_ranked_storage_miner(10, &miner_a, 100, true);
-		seed_ranked_storage_miner(11, &miner_b, 300, true);
-		// Inactive nodes must not receive a share or dilute the split.
-		seed_ranked_storage_miner(12, &inactive, 600, false);
+		seed_active_child(&fam_a, &child(10), 100);
+		seed_active_child(&fam_b, &child(11), 300);
 
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
 
-		assert_eq!(Balances::free_balance(&miner_a), 25_000);
-		assert_eq!(Balances::free_balance(&miner_b), 75_000);
-		assert_eq!(Balances::free_balance(&inactive), 0);
+		assert_eq!(Balances::free_balance(&fam_a), 25_000);
+		assert_eq!(Balances::free_balance(&fam_b), 75_000);
 		assert_eq!(Hippocampus::emission_available(), 0);
+	});
+}
+
+#[test]
+fn a_families_share_is_the_sum_of_its_childrens_weights() {
+	// fam_a runs three nodes, fam_b one. The split follows summed weight
+	// (300 vs 100), and fam_a receives ONE transfer, not three.
+	new_test_ext().execute_with(|| {
+		let (fam_a, fam_b) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_active_child(&fam_a, &child(10), 100);
+		seed_active_child(&fam_a, &child(11), 150);
+		seed_active_child(&fam_a, &child(12), 50);
+		seed_active_child(&fam_b, &child(13), 100);
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&fam_a), 75_000);
+		assert_eq!(Balances::free_balance(&fam_b), 25_000);
+		// Children are not payees — only the family account that put up the
+		// deposits receives emission.
+		for seed in [10u8, 11, 12, 13] {
+			assert_eq!(Balances::free_balance(&child(seed)), 0, "child {seed} was paid");
+		}
+	});
+}
+
+#[test]
+fn the_heaviest_family_takes_the_largest_share() {
+	// Three families, strictly ordered by summed child weight: the payout
+	// must preserve that order.
+	new_test_ext().execute_with(|| {
+		let (heavy, middle, light) = (account(2), account(3), account(4));
+		fund_bank_and_whitelist_admin(100_000);
+
+		// 30_000 / 15_000 / 5_000 — family totals well past u16::MAX territory
+		// once summed, which is what the u128 weight width is for.
+		seed_active_child(&heavy, &child(10), 15_000);
+		seed_active_child(&heavy, &child(11), 15_000);
+		seed_active_child(&middle, &child(12), 15_000);
+		seed_active_child(&light, &child(13), 5_000);
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		let (h, m, l) = (
+			Balances::free_balance(&heavy),
+			Balances::free_balance(&middle),
+			Balances::free_balance(&light),
+		);
+		assert_eq!(h, 60_000);
+		assert_eq!(m, 30_000);
+		assert_eq!(l, 10_000);
+		assert!(h > m && m > l);
+	});
+}
+
+#[test]
+fn family_weights_beyond_u16_are_not_flattened() {
+	// 35 children (MaxChildrenPerFamily) at MaxNodeWeight sums to 1_750_000 —
+	// 26x u16::MAX. A u16 accumulator would have clamped this family to 65_535
+	// and handed it a 1:1 split against a family a quarter its size instead of
+	// the 4:1 it earned.
+	new_test_ext().execute_with(|| {
+		let (big, small) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		let max_node_weight: u16 = <Runtime as pallet_arion::Config>::MaxNodeWeight::get();
+		for i in 0..35u8 {
+			seed_active_child(&big, &child(10 + i), max_node_weight);
+		}
+		for i in 0..9u8 {
+			seed_active_child(&small, &child(100 + i), max_node_weight);
+		}
+		// 35 : 9 — deliberately not a round ratio, so a clamped weight cannot
+		// coincidentally produce the same split.
+		let weights = pallet_arion::Pallet::<Runtime>::active_family_weights();
+		let of = |f: &AccountId| weights.iter().find(|(a, _)| a == f).unwrap().1;
+		assert_eq!(of(&big), 35 * u128::from(max_node_weight));
+		assert!(of(&big) > u128::from(u16::MAX));
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&big), 100_000 * 35 / 44);
+		assert_eq!(Balances::free_balance(&small), 100_000 * 9 / 44);
+	});
+}
+
+#[test]
+fn unbonding_children_neither_earn_nor_dilute() {
+	// A child that deregistered is in Unbonding with its deposit on the way
+	// out: it has nothing at risk, so its weight must not be paid for — and
+	// must not shrink everyone else's share either.
+	new_test_ext().execute_with(|| {
+		let (fam_a, exiting) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_active_child(&fam_a, &child(10), 100);
+		seed_child(&exiting, &child(11), 300, ChildStatus::Unbonding, 0);
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&exiting), 0);
+		// The whole payout, not 25% of it: the excluded weight is out of the
+		// denominator too.
+		assert_eq!(Balances::free_balance(&fam_a), 100_000);
+	});
+}
+
+#[test]
+fn a_family_whose_children_all_went_stale_is_excluded() {
+	// `NodeWeightByChild` keeps a node's last value until pruning gets to it.
+	// Without the freshness filter an offline node would keep collecting on
+	// its final good weight forever.
+	new_test_ext().execute_with(|| {
+		let (fresh, stale) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		let stale_after: u32 = <Runtime as pallet_arion::Config>::StaleChildBuckets::get();
+		seed_active_child(&fresh, &child(10), 100);
+		// One bucket past the staleness horizon.
+		seed_child(&stale, &child(11), 300, ChildStatus::Active, stale_after + 1);
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&stale), 0);
+		assert_eq!(Balances::free_balance(&fresh), 100_000);
+	});
+}
+
+#[test]
+fn a_child_exactly_at_the_staleness_horizon_still_earns() {
+	// The boundary is inclusive: `age == StaleChildBuckets` is still fresh,
+	// matching the family-scoring filter. An off-by-one here would silently
+	// stop paying every node reporting on the slowest allowed cadence.
+	new_test_ext().execute_with(|| {
+		let (borderline, fresh) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		let stale_after: u32 = <Runtime as pallet_arion::Config>::StaleChildBuckets::get();
+		seed_child(&borderline, &child(10), 100, ChildStatus::Active, stale_after);
+		seed_active_child(&fresh, &child(11), 100);
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&borderline), 50_000);
+		assert_eq!(Balances::free_balance(&fresh), 50_000);
+	});
+}
+
+#[test]
+fn unweighted_families_are_dropped_not_paid_zero() {
+	// A registered family whose children have never been scored contributes
+	// nothing, and must not occupy one of the `MaxMinersPerPayout` slots.
+	new_test_ext().execute_with(|| {
+		let (earning, unscored) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_active_child(&earning, &child(10), 100);
+		seed_active_child(&unscored, &child(11), 0);
+
+		let weights = pallet_arion::Pallet::<Runtime>::active_family_weights();
+		assert_eq!(weights.len(), 1, "zero-weight family should not occupy a payout slot");
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+		assert_eq!(Balances::free_balance(&earning), 100_000);
+		assert_eq!(Balances::free_balance(&unscored), 0);
 	});
 }
 
 #[test]
 fn pay_storage_miners_excludes_uid_238_account() {
 	new_test_ext().execute_with(|| {
-		let (miner_a, capture) = (account(2), account(5));
+		let (fam_a, capture) = (account(2), account(5));
 		fund_bank_and_whitelist_admin(100_000);
 
-		seed_ranked_storage_miner(10, &miner_a, 100, true);
-		seed_ranked_storage_miner(13, &capture, 300, true);
+		seed_active_child(&fam_a, &child(10), 100);
+		seed_active_child(&capture, &child(13), 300);
 
 		// Mark `capture` as the uid-238 (emission capture) account on the
-		// metagraph: it must be excluded and not dilute the miner split.
+		// metagraph: it must be excluded and not dilute the family split.
 		pallet_metagraph::UIDs::<Runtime>::put(vec![UID {
 			address: sp_core::sr25519::Public::from_raw([0u8; 32]),
 			id: 238,
@@ -159,51 +349,51 @@ fn pay_storage_miners_excludes_uid_238_account() {
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
 
 		assert_eq!(Balances::free_balance(&capture), 0);
-		assert_eq!(Balances::free_balance(&miner_a), 100_000);
+		assert_eq!(Balances::free_balance(&fam_a), 100_000);
 		assert_eq!(Hippocampus::emission_available(), 0);
 	});
 }
 
 #[test]
-fn unregistered_or_degraded_ranked_nodes_are_excluded() {
+fn the_ranking_pallet_no_longer_decides_who_gets_paid() {
+	// Explicit guard against a regression back to `RankingStorage`: a node
+	// sitting at the top of the storage ranking that is not an Arion family
+	// receives nothing, and an Arion family absent from the ranking is paid
+	// in full. If someone re-points the adapter at the ranking pallet, this
+	// test — not testnet — is where it fails.
 	new_test_ext().execute_with(|| {
-		let (miner_a, ghost, degraded) = (account(2), account(6), account(7));
+		let (family, ranked_only) = (account(2), account(6));
 		fund_bank_and_whitelist_admin(100_000);
 
-		seed_ranked_storage_miner(10, &miner_a, 100, true);
+		seed_active_child(&family, &child(10), 100);
 
-		// Ranked but never registered: the owner cannot be resolved.
+		let node_id = vec![14u8; 32];
+		pallet_registration::ColdkeyNodeRegistrationV2::<Runtime>::insert(
+			node_id.clone(),
+			Some(pallet_registration::ColdkeyNodeInfoLite {
+				node_id: node_id.clone(),
+				node_type: pallet_registration::NodeType::StorageMiner,
+				status: pallet_registration::Status::Online,
+				registered_at: 0u32.into(),
+				owner: ranked_only.clone(),
+			}),
+		);
 		let mut list = pallet_rankings::RankedList::<Runtime>::get();
 		list.push(pallet_rankings::NodeRankings {
-			rank: 14,
-			node_id: vec![14u8; 32],
-			node_ss58_address: ghost.to_ss58check().into_bytes(),
-			node_type: NodeType::StorageMiner,
-			weight: 300,
+			rank: 1,
+			node_id,
+			node_ss58_address: ranked_only.to_ss58check().into_bytes(),
+			node_type: pallet_registration::NodeType::StorageMiner,
+			weight: 60_000,
 			last_updated: 0u32.into(),
 			is_active: true,
 		});
 		pallet_rankings::RankedList::<Runtime>::put(list);
 
-		// Registered but degraded: registration refuses to resolve it.
-		seed_ranked_storage_miner(15, &degraded, 300, true);
-		pallet_registration::ColdkeyNodeRegistrationV2::<Runtime>::insert(
-			vec![15u8; 32],
-			Some(ColdkeyNodeInfoLite {
-				node_id: vec![15u8; 32],
-				node_type: NodeType::StorageMiner,
-				status: Status::Degraded,
-				registered_at: 0u32.into(),
-				owner: degraded.clone(),
-			}),
-		);
-
 		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
 
-		// Excluded nodes neither receive nor dilute the split.
-		assert_eq!(Balances::free_balance(&ghost), 0);
-		assert_eq!(Balances::free_balance(&degraded), 0);
-		assert_eq!(Balances::free_balance(&miner_a), 100_000);
+		assert_eq!(Balances::free_balance(&ranked_only), 0);
+		assert_eq!(Balances::free_balance(&family), 100_000);
 	});
 }
 

--- a/runtime/mainnet/tests/pay_storage_miners.rs
+++ b/runtime/mainnet/tests/pay_storage_miners.rs
@@ -9,7 +9,7 @@
 //! was the production bug: Arion operators never appear in that leaderboard,
 //! so registered families carrying real weight received nothing.
 
-use frame_support::traits::Currency;
+use frame_support::traits::{Currency, Get};
 use frame_support::{assert_noop, assert_ok};
 use hippius_mainnet_runtime::{
 	AccountId, ArionPayoutSource, Balances, Hippocampus, Runtime, RuntimeOrigin, System,
@@ -329,6 +329,36 @@ fn unweighted_families_are_dropped_not_paid_zero() {
 }
 
 #[test]
+fn a_family_is_not_paid_for_a_child_registered_to_someone_else() {
+	// `FamilyChildren` and `ChildRegistrations` are two indexes of one fact.
+	// The registration is authoritative: if a family's child list names a
+	// child whose registration points at a different family, that child's
+	// weight belongs to the other family and must not be credited here.
+	new_test_ext().execute_with(|| {
+		let (thief, owner) = (account(2), account(3));
+		fund_bank_and_whitelist_admin(100_000);
+
+		seed_active_child(&thief, &child(10), 100);
+		seed_active_child(&owner, &child(11), 300);
+		// Splice the owner's child into the thief's list without touching the
+		// child's registration.
+		pallet_arion::FamilyChildren::<Runtime>::mutate(&thief, |v| {
+			v.try_push(child(11)).expect("under MaxChildrenPerFamily");
+		});
+
+		let weights = pallet_arion::Pallet::<Runtime>::active_family_weights();
+		let of = |f: &AccountId| weights.iter().find(|(a, _)| a == f).map(|(_, w)| *w);
+		assert_eq!(of(&thief), Some(100), "thief was credited for a child it does not own");
+		assert_eq!(of(&owner), Some(300));
+
+		assert_ok!(Hippocampus::pay_storage_miners(RuntimeOrigin::signed(admin()), 100_000));
+
+		assert_eq!(Balances::free_balance(&thief), 25_000);
+		assert_eq!(Balances::free_balance(&owner), 75_000);
+	});
+}
+
+#[test]
 fn pay_storage_miners_excludes_uid_238_account() {
 	new_test_ext().execute_with(|| {
 		let (fam_a, capture) = (account(2), account(5));
@@ -395,6 +425,26 @@ fn the_ranking_pallet_no_longer_decides_who_gets_paid() {
 		assert_eq!(Balances::free_balance(&ranked_only), 0);
 		assert_eq!(Balances::free_balance(&family), 100_000);
 	});
+}
+
+#[test]
+fn the_payout_slot_bound_covers_every_family_that_can_exist() {
+	// `pay_storage_miners` rejects the WHOLE call when the payee set exceeds
+	// `MaxMinersPerPayout`, so a bound below the reachable family count is not
+	// a degraded payout — it is a total, silent halt of storage emission, with
+	// every missed day unrecoverable under the 24-hour cap.
+	//
+	// The reachable count is `MaxChildrenTotal`, not `MaxFamilies`: a family
+	// needs one Active child to carry weight, and `register_child` caps
+	// `TotalActiveChildren` unconditionally, whereas `MaxFamilies` is checked
+	// only on a family's first fee-free slot.
+	let max_payees: u32 = <Runtime as pallet_hippocampus::Config>::MaxMinersPerPayout::get();
+	let max_families: u32 = <Runtime as pallet_arion::Config>::MaxChildrenTotal::get();
+	assert!(
+		max_payees >= max_families,
+		"MaxMinersPerPayout ({max_payees}) must cover every family that can hold \
+		 an active child ({max_families}), or pay_storage_miners bricks entirely"
+	);
 }
 
 #[test]


### PR DESCRIPTION
updated pay_storage_miners to pay from arion pallet instead of rankingsStorage